### PR TITLE
feat(skills): add bdd-design and bdd-implement

### DIFF
--- a/skills/bdd-design/SKILL.md
+++ b/skills/bdd-design/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: bdd-design
+description: "Use when designing BDD features, writing Gherkin acceptance criteria, decomposing requirements into testable scenarios, creating GitHub issues with .feature specs, or specifying acceptance criteria for the implementation agent. Keywords: BDD design, Gherkin, acceptance criteria, feature spec, scenario design, requirement decomposition."
+---
+
+# BDD Design Skill
+
+**IRON LAW: Every step must be specific enough that an agent can derive test assertions from the step text alone.** If a step says "it works" or "the result is correct", it is too vague — rewrite it with concrete, verifiable expectations.
+
+You are Agent 1 (the design agent). Produce a GitHub issue containing Gherkin acceptance criteria and a design spec that Agent 2 (the implementation agent) will use to deliver working code with passing BDD tests.
+
+## Workflow Checklist
+
+Copy and track progress:
+
+```
+- [ ] ⚠️ 1. Understand the codebase (read AGENT.md, CLAUDE.md, src/, features/)
+- [ ] ⚠️ 2. Check existing step definitions (rara-bdd list)
+- [ ] ⚠️ 3. Write Gherkin .feature content (≥3 scenarios)
+- [ ] 4. Write design spec (files, signatures, constraints)
+- [ ] ⚠️ 5. Self-check (all checklist items pass)
+- [ ] ⛔ 6. Confirm with user before creating issue
+- [ ] 7. Create the GitHub issue
+```
+
+### 1. Understand the Codebase ⚠️
+
+Read the project context before writing anything:
+
+- Read `AGENT.md` — project conventions and architecture
+- Read `CLAUDE.md` — dev workflow and commands
+- Browse `src/` — source structure
+- Browse `features/` — existing .feature files (if any)
+
+### 2. Check Existing Step Definitions ⚠️
+
+Reuse existing steps — do NOT create duplicates.
+
+```bash
+rara-bdd list
+```
+
+If an existing step matches your intent (even partially), reuse its exact wording.
+
+### 3. Write Gherkin .feature Content ⚠️
+
+Create complete Gherkin content with **at least 3 scenarios**: one happy path, one error case, and one edge case.
+
+#### Rules
+
+- Tag the feature with `@module-name` (e.g., `@auth`, `@billing`)
+- Tag each scenario with `@AC-XX` (e.g., `@AC-01`, `@AC-02`)
+- Steps must be concrete and verifiable — can an agent derive test logic from the step text alone?
+- Use `"quoted strings"` for string parameters, bare integers for number parameters
+- Reuse existing step definitions discovered via `rara-bdd list`
+- Use `Given` for preconditions, `When` for actions, `Then` for assertions
+- Use `And` / `But` for continuation within the same keyword group
+
+#### Good vs Bad Examples
+
+```gherkin
+# BAD — too vague, agent cannot derive assertions
+@AC-01
+Scenario: User logs in
+  Given a user exists
+  When they log in
+  Then it works
+
+# BAD — implementation detail in steps (leaks internal API)
+@AC-01
+Scenario: User logs in
+  Given a row in the users table with id 1
+  When POST /api/v1/sessions with JSON body {"user_id": 1}
+  Then the sessions table has a new row
+
+# GOOD — specific, testable, no implementation leak
+@AC-01
+Scenario: Valid credentials return a session token
+  Given a registered user with email "alice@example.com"
+  When the user logs in with correct credentials
+  Then the response status is 200
+  And the response body contains a non-empty "token" field
+
+# GOOD — error case with clear expected behavior
+@AC-02
+Scenario: Invalid password returns 401
+  Given a registered user with email "alice@example.com"
+  When the user logs in with password "wrong-password"
+  Then the response status is 401
+  And the response body contains error "invalid credentials"
+
+# GOOD — edge case
+@AC-03
+Scenario: Login with non-existent email returns 404
+  Given no user is registered with email "ghost@example.com"
+  When the user logs in with email "ghost@example.com"
+  Then the response status is 404
+```
+
+### 4. Write the Design Spec
+
+Provide a concise design spec that tells the implementation agent exactly what to build:
+
+- **Files to create or modify** — list every file path
+- **Interface signatures** — public function/struct/trait signatures the implementation must expose
+- **Constraints** — invariants, error handling strategy, performance requirements
+- **Dependencies** — any new crates or services required
+
+### 5. Self-Check ⚠️
+
+Before presenting to the user, verify:
+
+- [ ] Valid Gherkin syntax (Feature/Scenario/Given/When/Then structure)
+- [ ] At least 3 scenarios (happy path + error + edge case)
+- [ ] Steps are concrete and verifiable (not vague)
+- [ ] Existing steps reused where applicable (checked via `rara-bdd list`)
+- [ ] `"quoted strings"` for string params, bare integers for numbers
+- [ ] Each scenario tagged with `@AC-XX`
+- [ ] Feature tagged with `@module-name`
+- [ ] Design spec lists all files to create/modify with signatures
+
+### 6. Confirm with User ⛔
+
+Present the complete Gherkin content and design spec to the user. Wait for explicit approval before creating the GitHub issue. Do NOT create the issue without confirmation.
+
+### 7. Create the GitHub Issue
+
+Use the `bdd_task.yml` issue template:
+
+```bash
+gh issue create --template bdd_task.yml \
+  --title "feat(scope): short description" \
+  --body "$(cat <<'EOF'
+### Description
+
+What should be implemented and why.
+
+### .feature (Acceptance Criteria)
+
+```gherkin
+@module-name
+Feature: Feature title
+
+  @AC-01
+  Scenario: Happy path description
+    Given ...
+    When ...
+    Then ...
+
+  @AC-02
+  Scenario: Error case description
+    Given ...
+    When ...
+    Then ...
+
+  @AC-03
+  Scenario: Edge case description
+    Given ...
+    When ...
+    Then ...
+```
+
+### Scope
+
+- `src/module.rs` — create: new module with XxxTrait
+- `src/lib.rs` — modify: add `pub mod module;`
+- `features/module.feature` — create: copy from above
+
+### Additional Context
+
+Design constraints, dependencies, notes.
+EOF
+)" --label "agent:claude" --label "enhancement" --label "core"
+```
+
+**Required labels:**
+- Agent label: `agent:claude` (or whichever agent is performing this)
+- Type label: auto-applied by template (`enhancement`)
+- Component label: one of `core`, `backend`, `frontend`, `cli`, `ci`, `docs`
+
+## Anti-Patterns
+
+- Writing vague steps like "it works", "result is correct", "operation succeeds"
+- Leaking implementation details into steps (SQL, HTTP methods, table names)
+- Ignoring existing step definitions and creating duplicates
+- Writing only the happy path — always include error + edge cases
+- Creating the issue without user confirmation

--- a/skills/bdd-implement/SKILL.md
+++ b/skills/bdd-implement/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: bdd-implement
+description: "Use when implementing a BDD-specced GitHub issue, writing step definitions, delivering code with passing cucumber tests, or picking up an agent-designed feature task. Keywords: BDD implement, step definition, cucumber test, implement issue, feature implementation, agent task."
+---
+
+# BDD Implement Skill
+
+**IRON LAW: NEVER modify the .feature file.** The .feature content is Agent 1's contract. If a scenario seems wrong, add a `needs-design-review` label to the issue and comment — do not change the Gherkin.
+
+You are Agent 2 (the implementation agent). Take a GitHub issue created by Agent 1 and deliver working code with all BDD tests passing.
+
+## Workflow Checklist
+
+Copy and track progress:
+
+```
+- [ ] ⚠️ 1. Read the issue (extract Gherkin + design spec)
+- [ ] 2. Create worktree
+- [ ] 3. Run rara-bdd setup (idempotent)
+- [ ] ⛔ 4. Write .feature file (VERBATIM from issue — never modify)
+- [ ] 5. Run rara-bdd generate
+- [ ] ⚠️ 6. Run rara-bdd coverage (must exit 0)
+- [ ] 7. Implement: types → logic → integration → steps
+- [ ] ⚠️ 8. Verify: coverage + test + clippy (ALL three must pass)
+- [ ] ⛔ 9. Confirm with user before push & PR
+- [ ] 10. Push & create PR
+- [ ] ⚠️ 11. Wait for CI green
+```
+
+### 1. Read the Issue ⚠️
+
+```bash
+gh issue view <N>
+```
+
+Extract:
+- The `.feature` Gherkin content (acceptance criteria)
+- The design spec (files to create/modify, interface signatures, constraints)
+- The component label (to know which area you are working in)
+
+### 2. Create Worktree
+
+Follow the standard org workflow:
+
+```bash
+git worktree add .worktrees/issue-<N>-<short-name> -b issue-<N>-<short-name>
+cd .worktrees/issue-<N>-<short-name>
+```
+
+All work happens inside the worktree. Never edit files in the main checkout.
+
+### 3. Run Setup (Idempotent)
+
+```bash
+rara-bdd setup
+```
+
+Safe to run even if already set up. Ensures `features/`, `tests/bdd.rs`, `tests/steps/mod.rs`, and Cargo.toml dependencies are in place.
+
+### 4. Write the .feature File ⛔
+
+Copy the Gherkin content from the issue **verbatim** into `features/<name>.feature`. Do NOT modify, reword, or reorder the scenarios.
+
+### 5. Generate Step Skeletons
+
+```bash
+rara-bdd generate
+```
+
+Creates `tests/steps/<name>_steps.rs` with `todo!()` bodies for each step.
+
+### 6. Check Coverage ⚠️
+
+```bash
+rara-bdd coverage
+```
+
+All steps from the .feature file must have skeleton definitions. If any are missing, run `rara-bdd generate` again.
+
+### 7. Implement
+
+Follow this order to minimize compile errors:
+
+1. **Data types** — structs, enums, error types referenced by the design spec
+2. **Core logic** — the main business logic (functions, trait implementations)
+3. **Integration** — wiring (module declarations, re-exports, dependency injection)
+4. **Step definitions** — replace every `todo!()` in `tests/steps/<name>_steps.rs`
+
+#### TestWorld Usage
+
+The `TestWorld` struct in `tests/bdd.rs` carries state between steps:
+
+- **Given steps** (setup): Initialize state in `TestWorld` fields
+- **When steps** (action): Execute the operation, store results in `TestWorld`
+- **Then steps** (assert): Read from `TestWorld` and assert expected outcomes
+
+```rust
+#[given(expr = "a registered user with email {string}")]
+async fn a_registered_user_with_email(world: &mut TestWorld, email: String) {
+    world.user_email = Some(email);
+}
+
+#[when("the user logs in with correct credentials")]
+async fn the_user_logs_in(world: &mut TestWorld) {
+    let email = world.user_email.as_ref().expect("email set in Given step");
+    world.response = Some(login(email, "correct-password").await);
+}
+
+#[then(expr = "the response status is {int}")]
+async fn the_response_status_is(world: &mut TestWorld, expected: i32) {
+    let response = world.response.as_ref().expect("response set in When step");
+    assert_eq!(response.status, expected as u16);
+}
+```
+
+Add new fields to `TestWorld` as needed. Keep it minimal — only fields shared between steps.
+
+### 8. Verify ⚠️
+
+All three checks must pass before proceeding:
+
+```bash
+rara-bdd coverage                # Exit 0 = all steps covered
+cargo test --test bdd            # All scenarios pass
+cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+```
+
+### 9. Confirm with User ⛔
+
+Present a summary of what was implemented (files changed, scenarios passing) and ask for confirmation before pushing. Do NOT push without approval.
+
+### 10. Push & Create PR
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+feat(scope): implement feature description (#N)
+
+Implement Gherkin acceptance criteria from issue #N.
+All BDD scenarios pass.
+
+Closes #N
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin issue-<N>-<short-name>
+
+gh pr create --title "feat(scope): implement feature description (#N)" --body "$(cat <<'PR_EOF'
+## Summary
+
+Implement acceptance criteria from #N.
+
+## Type of change
+
+| Type | Label |
+|------|-------|
+| New feature | `enhancement` |
+
+## Component
+
+`core`
+
+## Closes
+
+Closes #N
+
+## Test plan
+
+- [x] `rara-bdd coverage` — zero missing steps
+- [x] `cargo test --test bdd` — all scenarios pass
+- [x] `cargo clippy` — no warnings
+PR_EOF
+)" --label "enhancement" --label "core"
+```
+
+### 11. Wait for CI Green ⚠️
+
+```bash
+gh pr checks <PR-number> --watch
+```
+
+Do NOT report completion until all CI checks pass. If a check fails, investigate and fix in the worktree, push again, and re-verify.
+
+## Failure Handling
+
+| Failure | Action | Max Retries |
+|---------|--------|-------------|
+| Compile error | Read error output, fix the code, rebuild | 3 |
+| Missing step definition | Run `rara-bdd generate`, then implement | 1 |
+| Assertion failure in BDD test | Analyze expected vs actual, fix logic | 3 |
+| Clippy warning | Fix the warning | 3 |
+| Retries exhausted | Add `needs-human` label + post analysis comment on the issue | -- |
+
+When retries are exhausted:
+
+```bash
+gh issue edit <N> --add-label "needs-human"
+gh issue comment <N> --body "$(cat <<'EOF'
+## Agent stuck — needs human review
+
+**Failure type:** <compile error | assertion failure | ...>
+**Attempts:** 3/3
+**Last error:**
+```
+<paste last error output>
+```
+
+**Analysis:**
+<what the agent tried and why it did not work>
+EOF
+)"
+```
+
+## Anti-Patterns
+
+- Modifying the .feature file for any reason (add `needs-design-review` label instead)
+- Implementing steps before data types and core logic (causes compile cascade)
+- Pushing without all three verification checks passing
+- Silently giving up when retries are exhausted (must add `needs-human` label)
+- Adding unnecessary fields to `TestWorld` (keep it minimal)
+- Pushing or creating PRs without user confirmation


### PR DESCRIPTION
## Summary

- Add `bdd-design` skill — decompose requirements into GitHub issues with Gherkin acceptance criteria
- Add `bdd-implement` skill — pick up BDD-specced issues and deliver working code with passing tests
- Both skills follow Skill Forge standards (Iron Law, workflow checklist with ⚠️/⛔ markers, confirmation gates, anti-patterns)

Companion to rararulab/rara-bdd#10 which removes these skills from the tool repo and points here.

## Test plan

- [x] Skill files have valid frontmatter (name + description)
- [x] Both skills have Iron Law, workflow checklist, confirmation gates, anti-patterns
- [x] SKILL.md files are under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)