### PR TITLE
fix: rename plugin from dev-skills to rara

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   },
   "plugins": [
     {
-      "name": "dev-skills",
+      "name": "rara",
       "description": "Development workflow skills for orchestrating code implementation, review, and GitHub workflow via acpx",
       "source": "./",
       "strict": false,


### PR DESCRIPTION
## Summary
- 将 `.claude-plugin/marketplace.json` 中的 plugin name 从 `dev-skills` 重命名为 `rara`，使其与 marketplace 名称一致

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)