### PR TITLE
chore(core): fix marketplace.json to match plugin spec (#5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,23 +1,18 @@
 {
-  "name": "rara-skills",
+  "name": "rara-skills-dev",
+  "description": "Development marketplace for rara-skills plugin",
   "owner": {
-    "name": "rararulab",
-    "email": "rararulab@users.noreply.github.com"
-  },
-  "metadata": {
-    "description": "Rara's skill marketplace — agent skills for development, code review, and workflow orchestration",
-    "version": "1.0.0"
+    "name": "rararulab"
   },
   "plugins": [
     {
       "name": "rara",
-      "description": "Development workflow skills for orchestrating code implementation, review, and GitHub workflow via acpx",
+      "description": "Agent skills for development workflow, language learning, and requirement management",
+      "version": "1.0.0",
       "source": "./",
-      "strict": false,
-      "skills": [
-        "./skills/dev-workflow",
-        "./skills/requirement-to-issues"
-      ]
+      "author": {
+        "name": "rararulab"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Moves description/version to top-level (was nested in `metadata`)
- Adds `version` and `author` to plugin entry
- Removes manual `skills` array (auto-discovered from source)
- Renames marketplace to `rara-skills-dev`

Closes #5

## Test plan
- [ ] Verify marketplace.json validates against plugin spec
- [ ] Verify skills are auto-discovered from `./skills/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)