### PR TITLE
chore(core): fix SKILL.md description frontmatter (#6)

### DIFF
--- a/skills/dev-workflow/SKILL.md
+++ b/skills/dev-workflow/SKILL.md
@@ -1,13 +1,8 @@
 ---
 name: dev-workflow
 description: >
-  Orchestrates software development tasks by delegating work to Claude Code CLI
-  and Ralph (autonomous agent loop). Use this skill whenever rara needs to implement
-  features, fix bugs, review code, analyze requirements, create pull requests, or
-  perform any code-related development task. This includes writing code, reviewing
-  changes, managing issues, running CI checks, and handling the full development
-  lifecycle — even if the user just says "fix this bug" or "add a feature" without
-  mentioning agents or workflows explicitly.
+  Use when implementing features, fixing bugs, reviewing code, creating PRs,
+  or performing any code-related development task.
 ---
 
 IRON LAW: You never write code directly. Every code change — implementation,

--- a/skills/language-learning/SKILL.md
+++ b/skills/language-learning/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: language-learning
 description: >
-  Use in EVERY conversation with the user. Immersive Japanese language
-  learning blended into daily work interactions. Triggers: any user
-  message in any context.
+  Use when the user is a Japanese language learner. Blends immersive Japanese
+  practice into work interactions using kotoba for SRS tracking.
 ---
 
 # Immersive Japanese Learning

--- a/skills/requirement-to-issues/SKILL.md
+++ b/skills/requirement-to-issues/SKILL.md
@@ -1,13 +1,8 @@
 ---
 name: requirement-to-issues
 description: >
-  Convert user requirements into structured Linear issues for Symphony + ralph.
-  Use when a user sends a feature request, bug report, change request, or any
-  development need from Telegram, Slack, or direct conversation. Triggers on:
-  "I need", "can you add", "please fix", "we should", "implement", "build",
-  "add support for", "feature request", "bug report", "requirement", "需求",
-  "功能", "修复", "添加", "实现", "开发". Creates Linear issues with repo label
-  and Todo status. Does NOT write code or analyze repos — ralph handles that.
+  Use when a user sends a feature request, bug report, or change request.
+  Converts requirements into structured Linear issues.
 ---
 
 IRON LAW: YOU ARE A BRIDGE, NOT AN ENGINEER. NEVER analyze repo code, design


### PR DESCRIPTION
## Summary
- **dev-workflow**: shortened from process description to trigger conditions
- **language-learning**: replaced overly broad "Use in EVERY conversation" with specific trigger
- **requirement-to-issues**: trimmed from 7 lines with trigger word list to 2-line trigger condition

Closes #6

## Test plan
- [ ] Verify each skill still triggers correctly in Claude Code
- [ ] Verify no skill body content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)