### PR TITLE
docs(readme): add bdd-review + matklad-perspective, group skills by category

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,39 @@ Supports both git-based and marketplace installations. After upgrading, restart 
 
 ## Available Skills
 
+### Development workflow
+
 | Skill | Description |
 |-------|-------------|
 | [dev-workflow](./skills/dev-workflow/) | Full development lifecycle: issue → worktree → delegate → evaluate → PR → CI |
 | [requirement-to-issues](./skills/requirement-to-issues/) | Convert user requirements into structured Linear issues |
-| [language-learning](./skills/language-learning/) | Immersive Japanese learning blended into normal task conversations (no CLI required) |
-| [bdd-design](./skills/bdd-design/) | Design BDD scenarios from requirements |
-| [bdd-implement](./skills/bdd-implement/) | Implement BDD scenarios as executable tests |
-| [prompt-refinery](./skills/prompt-refinery/) | Optimize prompts using the Polanyi tacit-knowledge framework |
+
+### BDD (feature-driven development)
+
+| Skill | Description |
+|-------|-------------|
+| [bdd-design](./skills/bdd-design/) | Design BDD scenarios from requirements, write Gherkin acceptance criteria |
+| [bdd-review](./skills/bdd-review/) | Review `.feature` files for quality before issue creation |
+| [bdd-implement](./skills/bdd-implement/) | Implement BDD scenarios as executable tests with step definitions |
+
+### Prompt engineering
+
+| Skill | Description |
+|-------|-------------|
 | [prompt-system](./skills/prompt-system/) | Diagnose, optimize, or generate prompts with the seven-layer Polanyi framework |
+| [prompt-refinery](./skills/prompt-refinery/) | Optimize prompts using the Polanyi tacit-knowledge framework (concept anchors + constraint layering) |
+
+### Perspectives (thinking styles)
+
+| Skill | Description |
+|-------|-------------|
+| [matklad-perspective](./skills/matklad-perspective/) | Alex Kladov (matklad) thinking framework — use for IDE/compiler/language design, architecture decisions, testing methodology |
+
+### Other
+
+| Skill | Description |
+|-------|-------------|
+| [language-learning](./skills/language-learning/) | Immersive Japanese learning blended into normal task conversations (no CLI required) |
 | [rara-upgrade](./skills/rara-upgrade/) | Upgrade rara-skills to the latest version |
 
 ## Project vs User Install


### PR DESCRIPTION
## Summary
- Add two missing skills to the README's Available Skills section: `bdd-review` (previously undocumented) and `matklad-perspective` (newly added)
- Restructure the flat skill table into 5 semantic groups: **Development workflow**, **BDD**, **Prompt engineering**, **Perspectives**, **Other**
- Tighten `bdd-design` / `bdd-implement` descriptions and clarify the relationship between `prompt-refinery` and `prompt-system`

## Why
- The README listed 8 of the 10 actual skills, so contributors couldn't discover `bdd-review` or `matklad-perspective` from the landing page
- Grouping gives new contributors a lightweight taxonomy for where to place future skills

## Test plan
- [x] `git diff README.md` reviewed
- [ ] Visual check of rendered README on GitHub after merge
- [ ] Verify all skill links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)