### PR TITLE
feat(multica): make controller own stage handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Supports both git-based and marketplace installations. After upgrading, restart 
 | Skill | Description |
 |-------|-------------|
 | [dev-workflow](./skills/dev-workflow/) | Full development lifecycle: issue → worktree → delegate → evaluate → PR → CI |
-| [multica-team](./skills/multica-team/) | Rara-led coding orchestration through Multica: issue trees, explicit dispatch contracts, agent assignment, monitoring, verification, and deliberate ship/follow-up decisions |
+| [multica-team](./skills/multica-team/) | Rara-led coding orchestration through Multica: issue trees, explicit dispatch contracts, canonical stage-result artifacts, controller-aware handoffs, monitoring, verification, and deliberate ship/follow-up decisions |
 | [multica-polling](./skills/multica-polling/) | Scheduler-driven tracking for Multica-dispatched issues: persisted context, polling state machine, retry/timeout policy, and script-backed rescheduling |
-| [multica-orchestrator](./skills/multica-orchestrator/) | Stage-level Multica autonomy layer: validate plan/build/review artifacts, gate handoffs, reschedule corrections, and escalate when automatic transition is unsafe |
+| [multica-orchestrator](./skills/multica-orchestrator/) | Workflow-controller layer for staged Multica delivery: parse canonical STAGE_RESULT JSON, validate plan/build/review gates plus delivery evidence, emit authoritative handoff comments, and escalate when transition is unsafe |
 | [requirement-to-issues](./skills/requirement-to-issues/) | Convert user requirements into structured Linear issues |
 
 ### BDD (feature-driven development)

--- a/scripts/multica-orchestrate.ts
+++ b/scripts/multica-orchestrate.ts
@@ -10,10 +10,28 @@ type ObservedState =
   | "poll_error";
 
 type StageName = "plan" | "build" | "review";
-
+type WorkflowTerminalStage = StageName | "done";
 type ValidatorStatus = "pending" | "passed" | "failed";
-
 type OrchestratorKind = "reschedule" | "handoff" | "done" | "blocked" | "needs_human";
+type DeliveryMode =
+  | "commit+push"
+  | "commit+push+pr"
+  | "local-artifact"
+  | "issue-comment"
+  | "artifact+comment";
+
+type DeliveryStatus = "satisfied" | "fallback_used" | "missing" | "not_applicable";
+
+interface WorkflowStageSpec {
+  issue_id: string;
+  assignee_label?: string | null;
+}
+
+interface WorkflowGraph {
+  plan: WorkflowStageSpec;
+  build: WorkflowStageSpec;
+  review: WorkflowStageSpec;
+}
 
 interface StageHistoryEntry {
   stage: StageName;
@@ -24,14 +42,32 @@ interface StageHistoryEntry {
   outcome: OrchestratorKind;
   summary: string;
   recorded_at: string;
+  artifact_comment_id?: string | null;
+}
+
+interface TransitionAudit {
+  recorded_at: string;
+  stage: StageName;
+  issue_id: string;
+  task_id: string | null;
+  observed_state: ObservedState;
+  artifact_comment_id: string | null;
+  artifact_sha256: string | null;
+  validation_ok: boolean;
+  validator_status: ValidatorStatus;
+  decision: OrchestratorKind;
+  next_stage: WorkflowTerminalStage | null;
+  summary: string;
 }
 
 interface OrchestratorContext {
   workflow: "multica_orchestrator";
+  schema_version: 2;
   root_issue_id: string;
+  workflow_graph: WorkflowGraph;
   current_stage: StageName;
   current_issue_id: string;
-  next_stage: StageName | "done" | null;
+  next_stage: WorkflowTerminalStage | null;
   attempt: number;
   last_task_id: string | null;
   last_observed_status: ObservedState | null;
@@ -39,13 +75,39 @@ interface OrchestratorContext {
   handoff_ready: boolean;
   escalation_count: number;
   max_stage_attempts: number;
+  expected_delivery_mode: DeliveryMode | null;
   history: StageHistoryEntry[];
+  last_transition_audit: TransitionAudit | null;
+}
+
+interface DeliveryEvidence {
+  mode?: string | null;
+  status?: string | null;
+  branch?: string | null;
+  commit_sha?: string | null;
+  pr_url?: string | null;
+  artifact_path?: string | null;
+  comment_ref?: string | null;
 }
 
 interface ArtifactInput {
+  schema_version?: number | null;
   stage?: string;
+  status?: string | null;
+  summary?: string | null;
   verdict?: string | null;
+  next_recommendation?: string | null;
+  comment_id?: string | null;
+  source?: string | null;
   fields?: Record<string, unknown>;
+  delivery?: DeliveryEvidence | null;
+}
+
+interface ParseArtifactResult {
+  ok: boolean;
+  artifact: ArtifactInput | null;
+  summary: string;
+  source: "json" | "fenced_json" | "none";
 }
 
 interface EvaluateInput {
@@ -64,6 +126,12 @@ interface ValidationResult {
   invalid_fields: string[];
   summary: string;
   next_recommendation: OrchestratorKind;
+  delivery_check: {
+    required: boolean;
+    expected_mode: DeliveryMode | null;
+    status: DeliveryStatus;
+    summary: string;
+  };
 }
 
 interface EvaluateResult {
@@ -72,13 +140,15 @@ interface EvaluateResult {
   kind: OrchestratorKind;
   current_stage: StageName;
   current_issue_id: string;
-  next_stage: StageName | "done" | null;
+  next_stage: WorkflowTerminalStage | null;
   task_id: string | null;
   validator_status: ValidatorStatus;
   handoff_ready: boolean;
   summary: string;
   validation: ValidationResult | null;
   next_context: OrchestratorContext | null;
+  transition_audit: TransitionAudit | null;
+  authoritative_comment: string | null;
   schedule_message: string | null;
   exit_code: number;
 }
@@ -109,10 +179,14 @@ const REQUIRED_FIELDS: Record<StageName, string[]> = {
   ],
 };
 
+const STAGE_ORDER: StageName[] = ["plan", "build", "review"];
+
 function printUsage(): never {
   console.error(`Usage:
-  bun scripts/multica-orchestrate.ts init --root-issue-id ISSUE-100 --current-stage plan --current-issue-id ISSUE-101 [--next-stage build] [--max-stage-attempts 2]
+  bun scripts/multica-orchestrate.ts init --root-issue-id ISSUE-100 --plan-issue-id ISSUE-101 --build-issue-id ISSUE-102 --review-issue-id ISSUE-103 [--current-stage plan] [--max-stage-attempts 2] [--expected-delivery-mode commit+push]
   bun scripts/multica-orchestrate.ts evaluate --context-json '{...}' --observed-state completed [--task-id TASK-1] [--artifact-json '{...}'] [--summary '...'] [--now ISO]
+  bun scripts/multica-orchestrate.ts parse-artifact --text-file ./comment.md
+  bun scripts/multica-orchestrate.ts render-handoff-comment --context-json '{...}' --decision-json '{...}'
   bun scripts/multica-orchestrate.ts schedule-message --context-json '{...}'
 `);
   process.exit(2);
@@ -151,11 +225,36 @@ function isStageName(value: string | null | undefined): value is StageName {
   return value === "plan" || value === "build" || value === "review";
 }
 
-function normalizeNextStage(value: string | null | undefined): StageName | "done" | null {
+function isDeliveryMode(value: string | null | undefined): value is DeliveryMode {
+  return value === "commit+push"
+    || value === "commit+push+pr"
+    || value === "local-artifact"
+    || value === "issue-comment"
+    || value === "artifact+comment";
+}
+
+function normalizeNextStage(value: string | null | undefined): WorkflowTerminalStage | null {
   if (!value) return null;
   if (value === "done") return "done";
   if (isStageName(value)) return value;
   throw new Error(`invalid next stage: ${value}`);
+}
+
+function nextStageFor(stage: StageName): WorkflowTerminalStage {
+  const idx = STAGE_ORDER.indexOf(stage);
+  return idx >= 0 && idx < STAGE_ORDER.length - 1 ? STAGE_ORDER[idx + 1]! : "done";
+}
+
+function normalizeWorkflowGraph(raw: Partial<WorkflowGraph> | undefined, fallbackCurrentIssueId?: string): WorkflowGraph {
+  const planIssue = raw?.plan?.issue_id ?? fallbackCurrentIssueId;
+  if (!planIssue || !raw?.build?.issue_id || !raw?.review?.issue_id) {
+    throw new Error("workflow_graph requires plan/build/review issue_id values");
+  }
+  return {
+    plan: { issue_id: planIssue, assignee_label: raw?.plan?.assignee_label ?? null },
+    build: { issue_id: raw.build.issue_id, assignee_label: raw.build.assignee_label ?? null },
+    review: { issue_id: raw.review.issue_id, assignee_label: raw.review.assignee_label ?? null },
+  };
 }
 
 function validateContext(ctx: Partial<OrchestratorContext>): OrchestratorContext {
@@ -164,14 +263,19 @@ function validateContext(ctx: Partial<OrchestratorContext>): OrchestratorContext
   }
   if (!ctx.root_issue_id) throw new Error("context.root_issue_id is required");
   if (!isStageName(ctx.current_stage)) throw new Error("context.current_stage must be plan/build/review");
-  if (!ctx.current_issue_id) throw new Error("context.current_issue_id is required");
+
+  const workflowGraph = normalizeWorkflowGraph(ctx.workflow_graph, ctx.current_issue_id);
+  const currentIssueId = ctx.current_issue_id ?? workflowGraph[ctx.current_stage].issue_id;
+  if (!currentIssueId) throw new Error("context.current_issue_id is required");
 
   return {
     workflow: "multica_orchestrator",
+    schema_version: 2,
     root_issue_id: ctx.root_issue_id,
+    workflow_graph: workflowGraph,
     current_stage: ctx.current_stage,
-    current_issue_id: ctx.current_issue_id,
-    next_stage: normalizeNextStage(ctx.next_stage),
+    current_issue_id: currentIssueId,
+    next_stage: normalizeNextStage(ctx.next_stage ?? nextStageFor(ctx.current_stage)),
     attempt: Number(ctx.attempt ?? 1),
     last_task_id: ctx.last_task_id ?? null,
     last_observed_status: (ctx.last_observed_status ?? null) as ObservedState | null,
@@ -179,39 +283,59 @@ function validateContext(ctx: Partial<OrchestratorContext>): OrchestratorContext
     handoff_ready: Boolean(ctx.handoff_ready ?? false),
     escalation_count: Number(ctx.escalation_count ?? 0),
     max_stage_attempts: Number(ctx.max_stage_attempts ?? 2),
+    expected_delivery_mode: isDeliveryMode(ctx.expected_delivery_mode ?? null) ? ctx.expected_delivery_mode! : null,
     history: Array.isArray(ctx.history) ? ctx.history : [],
+    last_transition_audit: ctx.last_transition_audit ?? null,
   };
 }
 
 function buildScheduleMessage(context: OrchestratorContext): string {
   return [
-    "Continue Multica stage orchestration for this workflow.",
+    "Continue Multica workflow control for this staged issue tree.",
     "",
     "Context:",
     JSON.stringify(context, null, 2),
     "",
-    "Instructions:",
+    "Controller rules:",
     "1. Inspect the current issue/task execution state.",
-    "2. If execution is non-terminal, reschedule.",
-    "3. If execution is terminal, parse the stage artifact.",
-    "4. Validate the artifact for the current stage.",
-    "5. If validation passes, hand off to the next stage or finish the workflow.",
-    "6. If validation fails, issue a corrective follow-up or escalate according to attempt budget.",
+    "2. If execution is non-terminal, reschedule without changing stage ownership.",
+    "3. If execution is terminal, parse only the canonical STAGE_RESULT artifact.",
+    "4. Validate required stage fields and delivery-mode evidence.",
+    "5. Only after validator pass may you post an authoritative handoff note and reassign the next-stage issue.",
+    "6. Keep task failure, poller failure, and validator failure separate in reporting.",
+    "7. Persist the updated context and transition audit into the next scheduled message.",
   ].join("\n");
 }
 
 function initContext(): OrchestratorContext {
-  const currentStage = requireArg("--current-stage");
+  const currentStage = getArg("--current-stage") || "plan";
   if (!isStageName(currentStage)) {
     throw new Error("--current-stage must be one of: plan, build, review");
   }
 
+  const workflowGraph = normalizeWorkflowGraph({
+    plan: {
+      issue_id: requireArg("--plan-issue-id"),
+      assignee_label: getArg("--plan-assignee-label"),
+    },
+    build: {
+      issue_id: requireArg("--build-issue-id"),
+      assignee_label: getArg("--build-assignee-label"),
+    },
+    review: {
+      issue_id: requireArg("--review-issue-id"),
+      assignee_label: getArg("--review-assignee-label"),
+    },
+  });
+
   return validateContext({
     workflow: "multica_orchestrator",
+    schema_version: 2,
     root_issue_id: requireArg("--root-issue-id"),
+    workflow_graph: workflowGraph,
     current_stage: currentStage,
-    current_issue_id: requireArg("--current-issue-id"),
-    next_stage: normalizeNextStage(getArg("--next-stage")),
+    current_issue_id: workflowGraph[currentStage].issue_id,
+    next_stage: nextStageFor(currentStage),
     attempt: 1,
     last_task_id: null,
     last_observed_status: null,
@@ -219,7 +343,11 @@ function initContext(): OrchestratorContext {
     handoff_ready: false,
     escalation_count: 0,
     max_stage_attempts: parseIntSafe(getArg("--max-stage-attempts"), 2),
+    expected_delivery_mode: isDeliveryMode(getArg("--expected-delivery-mode"))
+      ? (getArg("--expected-delivery-mode") as DeliveryMode)
+      : null,
     history: [],
+    last_transition_audit: null,
   });
 }
 
@@ -233,11 +361,138 @@ function artifactFields(artifact: ArtifactInput | null | undefined): Record<stri
   return artifact?.fields && typeof artifact.fields === "object" ? artifact.fields : {};
 }
 
-function validateArtifact(stage: StageName, artifact: ArtifactInput | null | undefined): ValidationResult {
+async function readTextFile(filePath: string): Promise<string> {
+  return await Bun.file(filePath).text();
+}
+
+function tryParseArtifactFromText(text: string): ParseArtifactResult {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return { ok: false, artifact: null, summary: "No artifact text provided.", source: "none" };
+  }
+
+  try {
+    const direct = JSON.parse(trimmed) as ArtifactInput;
+    return { ok: true, artifact: direct, summary: "Parsed artifact from raw JSON.", source: "json" };
+  } catch {
+    // ignore
+  }
+
+  const fencedMatches = [...trimmed.matchAll(/```(?:json)?\s*([\s\S]*?)```/g)];
+  for (const match of fencedMatches) {
+    const payload = match[1]?.trim();
+    if (!payload) continue;
+    try {
+      const parsed = JSON.parse(payload) as ArtifactInput;
+      if (parsed && typeof parsed === "object" && parsed.stage) {
+        return {
+          ok: true,
+          artifact: parsed,
+          summary: "Parsed artifact from fenced JSON block.",
+          source: "fenced_json",
+        };
+      }
+    } catch {
+      // continue
+    }
+  }
+
+  return {
+    ok: false,
+    artifact: null,
+    summary: "No canonical JSON STAGE_RESULT artifact found.",
+    source: "none",
+  };
+}
+
+function normalizeDeliveryStatus(value: string | null | undefined): DeliveryStatus {
+  if (value === "satisfied" || value === "fallback_used" || value === "missing" || value === "not_applicable") {
+    return value;
+  }
+  return "missing";
+}
+
+async function sha256Hex(input: string | null | undefined): Promise<string | null> {
+  const raw = asNonEmptyString(input);
+  if (!raw) return null;
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(raw));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function deliveryCheck(
+  stage: StageName,
+  expectedMode: DeliveryMode | null,
+  artifact: ArtifactInput | null | undefined,
+): ValidationResult["delivery_check"] {
+  if (stage !== "build") {
+    return {
+      required: false,
+      expected_mode: expectedMode,
+      status: "not_applicable",
+      summary: "Delivery-mode gate is only enforced on build stage.",
+    };
+  }
+
+  const delivery = artifact?.delivery ?? null;
+  const observedMode = asNonEmptyString(delivery?.mode);
+  const status = normalizeDeliveryStatus(asNonEmptyString(delivery?.status));
+
+  if (!expectedMode) {
+    return {
+      required: true,
+      expected_mode: null,
+      status,
+      summary: "Build delivery-mode gate cannot be verified because expected_delivery_mode is missing from controller context.",
+    };
+  }
+
+  if (observedMode !== expectedMode) {
+    return {
+      required: true,
+      expected_mode: expectedMode,
+      status: "missing",
+      summary: `Build delivery mode mismatch: expected ${expectedMode}, observed ${observedMode ?? "none"}.`,
+    };
+  }
+
+  if (status !== "satisfied" && status !== "fallback_used") {
+    return {
+      required: true,
+      expected_mode: expectedMode,
+      status,
+      summary: `Build delivery mode ${expectedMode} is not yet satisfied.` ,
+    };
+  }
+
+  return {
+    required: true,
+    expected_mode: expectedMode,
+    status,
+    summary: `Build delivery mode ${expectedMode} verified as ${status}.`,
+  };
+}
+
+function validateArtifact(
+  stage: StageName,
+  artifact: ArtifactInput | null | undefined,
+  expectedDeliveryMode: DeliveryMode | null,
+): ValidationResult {
   const fields = artifactFields(artifact);
   const required = REQUIRED_FIELDS[stage];
   const missing_fields: string[] = [];
   const invalid_fields: string[] = [];
+
+  if (artifact?.schema_version !== 1) {
+    invalid_fields.push("schema_version");
+  }
+
+  if (asNonEmptyString(artifact?.status) !== "ready_for_handoff") {
+    invalid_fields.push("status");
+  }
+
+  if (!asNonEmptyString(artifact?.summary)) {
+    missing_fields.push("summary");
+  }
 
   for (const key of required) {
     const value = key === "verdict" ? (artifact?.verdict ?? fields[key]) : fields[key];
@@ -257,6 +512,11 @@ function validateArtifact(stage: StageName, artifact: ArtifactInput | null | und
     }
   }
 
+  const delivery = deliveryCheck(stage, expectedDeliveryMode, artifact);
+  if (delivery.required && delivery.status !== "satisfied" && delivery.status !== "fallback_used") {
+    invalid_fields.push("delivery");
+  }
+
   const ok = missing_fields.length === 0 && invalid_fields.length === 0;
   const next_recommendation: OrchestratorKind = ok
     ? stage === "review"
@@ -271,6 +531,7 @@ function validateArtifact(stage: StageName, artifact: ArtifactInput | null | und
     const parts: string[] = [];
     if (missing_fields.length > 0) parts.push(`missing: ${missing_fields.join(", ")}`);
     if (invalid_fields.length > 0) parts.push(`invalid: ${invalid_fields.join(", ")}`);
+    parts.push(delivery.summary);
     summary = `${stage} artifact validation failed (${parts.join("; ")}).`;
   }
 
@@ -281,6 +542,7 @@ function validateArtifact(stage: StageName, artifact: ArtifactInput | null | und
     invalid_fields,
     summary,
     next_recommendation,
+    delivery_check: delivery,
   };
 }
 
@@ -292,6 +554,7 @@ function pushHistory(
   outcome: OrchestratorKind,
   summary: string,
   recordedAt: string,
+  artifactCommentId: string | null,
 ): StageHistoryEntry[] {
   return [
     ...context.history,
@@ -304,15 +567,86 @@ function pushHistory(
       outcome,
       summary,
       recorded_at: recordedAt,
+      artifact_comment_id: artifactCommentId,
     },
   ];
 }
 
-function evaluate(input: EvaluateInput): EvaluateResult {
+function buildTransitionAudit(args: {
+  context: OrchestratorContext;
+  observedState: ObservedState;
+  taskId: string | null;
+  artifact: ArtifactInput | null | undefined;
+  artifactSha: string | null;
+  validationOk: boolean;
+  validatorStatus: ValidatorStatus;
+  decision: OrchestratorKind;
+  nextStage: WorkflowTerminalStage | null;
+  summary: string;
+  now: string;
+}): TransitionAudit {
+  return {
+    recorded_at: args.now,
+    stage: args.context.current_stage,
+    issue_id: args.context.current_issue_id,
+    task_id: args.taskId,
+    observed_state: args.observedState,
+    artifact_comment_id: args.artifact?.comment_id ?? null,
+    artifact_sha256: args.artifactSha,
+    validation_ok: args.validationOk,
+    validator_status: args.validatorStatus,
+    decision: args.decision,
+    next_stage: args.nextStage,
+    summary: args.summary,
+  };
+}
+
+function renderAuthoritativeComment(context: OrchestratorContext, result: EvaluateResult): string | null {
+  if (!result.transition_audit) return null;
+  const audit = result.transition_audit;
+  const lines = [
+    "## WORKFLOW_CONTROLLER_DECISION",
+    `stage: ${audit.stage}`,
+    `issue_id: ${audit.issue_id}`,
+    `task_id: ${audit.task_id ?? "n/a"}`,
+    `observed_state: ${audit.observed_state}`,
+    `validator_status: ${audit.validator_status}`,
+    `decision: ${audit.decision}`,
+    `next_stage: ${audit.next_stage ?? "n/a"}`,
+    `artifact_comment_id: ${audit.artifact_comment_id ?? "n/a"}`,
+    `artifact_sha256: ${audit.artifact_sha256 ?? "n/a"}`,
+    "",
+    "## SUMMARY",
+    result.summary,
+  ];
+
+  if (result.validation) {
+    lines.push(
+      "",
+      "## VALIDATION",
+      `summary: ${result.validation.summary}`,
+      `delivery_check: ${result.validation.delivery_check.summary}`,
+    );
+  }
+
+  if (result.kind === "handoff" && result.next_stage && result.next_stage !== "done") {
+    const nextSpec = context.workflow_graph[result.next_stage];
+    lines.push(
+      "",
+      "## NEXT_ACTION",
+      `Post this as the authoritative handoff note, then assign ${nextSpec.issue_id} to ${nextSpec.assignee_label ?? "the configured next-stage agent"}.`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+async function evaluate(input: EvaluateInput): Promise<EvaluateResult> {
   const context = validateContext(input.context);
   const observedState = input.observed_state;
   const now = input.now || nowIso();
   const taskId = input.task_id ?? context.last_task_id ?? null;
+  const artifactSha = await sha256Hex(input.artifact ? JSON.stringify(input.artifact) : null);
 
   if (observedState === "no_run_yet" || observedState === "queued" || observedState === "running") {
     const nextContext = validateContext({
@@ -333,9 +667,11 @@ function evaluate(input: EvaluateInput): EvaluateResult {
       task_id: taskId,
       validator_status: "pending",
       handoff_ready: false,
-      summary: input.summary || `Stage ${context.current_stage} is still ${observedState}; orchestration will continue.`,
+      summary: input.summary || `Stage ${context.current_stage} is still ${observedState}; controller will continue waiting.`,
       validation: null,
       next_context: nextContext,
+      transition_audit: null,
+      authoritative_comment: null,
       schedule_message: buildScheduleMessage(nextContext),
       exit_code: 10,
     };
@@ -344,25 +680,31 @@ function evaluate(input: EvaluateInput): EvaluateResult {
   if (observedState === "poll_error") {
     const nextEscalationCount = context.escalation_count + 1;
     if (nextEscalationCount >= context.max_stage_attempts) {
+      const summary = input.summary || `Observation failed repeatedly for stage ${context.current_stage}; human intervention required.`;
+      const audit = buildTransitionAudit({
+        context,
+        observedState,
+        taskId,
+        artifact: input.artifact,
+        artifactSha,
+        validationOk: false,
+        validatorStatus: context.validator_status,
+        decision: "needs_human",
+        nextStage: context.next_stage,
+        summary,
+        now,
+      });
       const nextContext = validateContext({
         ...context,
         last_task_id: taskId,
         last_observed_status: observedState,
-        validator_status: context.validator_status,
         handoff_ready: false,
         escalation_count: nextEscalationCount,
-        history: pushHistory(
-          context,
-          observedState,
-          taskId,
-          context.validator_status,
-          "needs_human",
-          input.summary || `Observation failed repeatedly for stage ${context.current_stage}.`,
-          now,
-        ),
+        history: pushHistory(context, observedState, taskId, context.validator_status, "needs_human", summary, now, input.artifact?.comment_id ?? null),
+        last_transition_audit: audit,
       });
 
-      return {
+      const result: EvaluateResult = {
         ok: false,
         terminal: true,
         kind: "needs_human",
@@ -372,12 +714,16 @@ function evaluate(input: EvaluateInput): EvaluateResult {
         task_id: taskId,
         validator_status: context.validator_status,
         handoff_ready: false,
-        summary: input.summary || `Observation failed repeatedly for stage ${context.current_stage}; human intervention required.`,
+        summary,
         validation: null,
         next_context: nextContext,
+        transition_audit: audit,
+        authoritative_comment: null,
         schedule_message: null,
         exit_code: 40,
       };
+      result.authoritative_comment = renderAuthoritativeComment(context, result);
+      return result;
     }
 
     const nextContext = validateContext({
@@ -398,33 +744,42 @@ function evaluate(input: EvaluateInput): EvaluateResult {
       task_id: taskId,
       validator_status: context.validator_status,
       handoff_ready: false,
-      summary: input.summary || `Observation failed for stage ${context.current_stage}; retrying with bounded budget.`,
+      summary: input.summary || `Observation failed for stage ${context.current_stage}; bounded retry will continue.`,
       validation: null,
       next_context: nextContext,
+      transition_audit: null,
+      authoritative_comment: null,
       schedule_message: buildScheduleMessage(nextContext),
       exit_code: 11,
     };
   }
 
   if (observedState === "failed" || observedState === "cancelled") {
+    const summary = input.summary || `Stage ${context.current_stage} execution ended as ${observedState}; automatic handoff stopped.`;
+    const audit = buildTransitionAudit({
+      context,
+      observedState,
+      taskId,
+      artifact: input.artifact,
+      artifactSha,
+      validationOk: false,
+      validatorStatus: "failed",
+      decision: "blocked",
+      nextStage: context.next_stage,
+      summary,
+      now,
+    });
     const nextContext = validateContext({
       ...context,
       last_task_id: taskId,
       last_observed_status: observedState,
       validator_status: "failed",
       handoff_ready: false,
-      history: pushHistory(
-        context,
-        observedState,
-        taskId,
-        "failed",
-        "blocked",
-        input.summary || `Stage ${context.current_stage} execution ended as ${observedState}.`,
-        now,
-      ),
+      history: pushHistory(context, observedState, taskId, "failed", "blocked", summary, now, input.artifact?.comment_id ?? null),
+      last_transition_audit: audit,
     });
 
-    return {
+    const result: EvaluateResult = {
       ok: false,
       terminal: true,
       kind: "blocked",
@@ -434,19 +789,39 @@ function evaluate(input: EvaluateInput): EvaluateResult {
       task_id: taskId,
       validator_status: "failed",
       handoff_ready: false,
-      summary: input.summary || `Stage ${context.current_stage} execution ended as ${observedState}; automatic handoff stopped.`,
+      summary,
       validation: null,
       next_context: nextContext,
+      transition_audit: audit,
+      authoritative_comment: null,
       schedule_message: null,
       exit_code: 20,
     };
+    result.authoritative_comment = renderAuthoritativeComment(context, result);
+    return result;
   }
 
-  const validation = validateArtifact(context.current_stage, input.artifact);
+  const validation = validateArtifact(context.current_stage, input.artifact, context.expected_delivery_mode);
   if (!validation.ok) {
     const nextAttempt = context.attempt + 1;
     const exhausted = nextAttempt > context.max_stage_attempts;
     const outcome: OrchestratorKind = exhausted ? "needs_human" : "reschedule";
+    const summary = exhausted
+      ? `${validation.summary} Automatic stage retries are exhausted.`
+      : `${validation.summary} A corrective follow-up should be issued for the same stage.`;
+    const audit = buildTransitionAudit({
+      context,
+      observedState,
+      taskId,
+      artifact: input.artifact,
+      artifactSha,
+      validationOk: false,
+      validatorStatus: "failed",
+      decision: outcome,
+      nextStage: context.next_stage,
+      summary,
+      now,
+    });
     const nextContext = validateContext({
       ...context,
       attempt: nextAttempt,
@@ -455,10 +830,11 @@ function evaluate(input: EvaluateInput): EvaluateResult {
       validator_status: "failed",
       handoff_ready: false,
       escalation_count: exhausted ? context.escalation_count + 1 : context.escalation_count,
-      history: pushHistory(context, observedState, taskId, "failed", outcome, validation.summary, now),
+      history: pushHistory(context, observedState, taskId, "failed", outcome, validation.summary, now, input.artifact?.comment_id ?? null),
+      last_transition_audit: audit,
     });
 
-    return {
+    const result: EvaluateResult = {
       ok: !exhausted,
       terminal: exhausted,
       kind: outcome,
@@ -468,83 +844,77 @@ function evaluate(input: EvaluateInput): EvaluateResult {
       task_id: taskId,
       validator_status: "failed",
       handoff_ready: false,
-      summary: exhausted
-        ? `${validation.summary} Automatic stage retries are exhausted.`
-        : `${validation.summary} A corrective follow-up should be issued for the same stage.`,
+      summary,
       validation,
       next_context: nextContext,
+      transition_audit: audit,
+      authoritative_comment: null,
       schedule_message: exhausted ? null : buildScheduleMessage(nextContext),
       exit_code: exhausted ? 41 : 12,
     };
+    result.authoritative_comment = renderAuthoritativeComment(context, result);
+    return result;
   }
 
   const terminalKind: OrchestratorKind = validation.next_recommendation;
+  const resolvedNextStage: WorkflowTerminalStage | null = terminalKind === "done"
+    ? "done"
+    : terminalKind === "handoff"
+      ? context.next_stage
+      : context.next_stage;
+  const summary = input.summary || (
+    terminalKind === "done"
+      ? `Stage ${context.current_stage} passed validation and the workflow is complete.`
+      : terminalKind === "blocked"
+        ? `Stage ${context.current_stage} validated but recommended a blocking verdict.`
+        : `Stage ${context.current_stage} passed validation and is ready for handoff to ${context.next_stage}.`
+  );
+  const audit = buildTransitionAudit({
+    context,
+    observedState,
+    taskId,
+    artifact: input.artifact,
+    artifactSha,
+    validationOk: true,
+    validatorStatus: "passed",
+    decision: terminalKind,
+    nextStage: resolvedNextStage,
+    summary,
+    now,
+  });
   const nextContext = validateContext({
     ...context,
     last_task_id: taskId,
     last_observed_status: observedState,
     validator_status: "passed",
     handoff_ready: terminalKind === "handoff" || terminalKind === "done",
-    history: pushHistory(context, observedState, taskId, "passed", terminalKind, validation.summary, now),
+    history: pushHistory(context, observedState, taskId, "passed", terminalKind, validation.summary, now, input.artifact?.comment_id ?? null),
+    last_transition_audit: audit,
   });
 
-  if (terminalKind === "done") {
-    return {
-      ok: true,
-      terminal: true,
-      kind: "done",
-      current_stage: context.current_stage,
-      current_issue_id: context.current_issue_id,
-      next_stage: "done",
-      task_id: taskId,
-      validator_status: "passed",
-      handoff_ready: true,
-      summary: input.summary || `Stage ${context.current_stage} passed validation and the workflow is complete.`,
-      validation,
-      next_context: nextContext,
-      schedule_message: null,
-      exit_code: 0,
-    };
-  }
-
-  if (terminalKind === "blocked") {
-    return {
-      ok: false,
-      terminal: true,
-      kind: "blocked",
-      current_stage: context.current_stage,
-      current_issue_id: context.current_issue_id,
-      next_stage: context.next_stage,
-      task_id: taskId,
-      validator_status: "passed",
-      handoff_ready: false,
-      summary: input.summary || `Stage ${context.current_stage} validated but recommended a blocking verdict.`,
-      validation,
-      next_context: nextContext,
-      schedule_message: null,
-      exit_code: 21,
-    };
-  }
-
-  return {
-    ok: true,
+  const result: EvaluateResult = {
+    ok: terminalKind !== "blocked",
     terminal: true,
-    kind: "handoff",
+    kind: terminalKind,
     current_stage: context.current_stage,
     current_issue_id: context.current_issue_id,
-    next_stage: context.next_stage,
+    next_stage: terminalKind === "done" ? "done" : context.next_stage,
     task_id: taskId,
     validator_status: "passed",
-    handoff_ready: true,
-    summary: input.summary || `Stage ${context.current_stage} passed validation and is ready for handoff to ${context.next_stage}.`,
+    handoff_ready: terminalKind === "handoff" || terminalKind === "done",
+    summary,
     validation,
     next_context: nextContext,
+    transition_audit: audit,
+    authoritative_comment: null,
     schedule_message: null,
-    exit_code: 30,
+    exit_code: terminalKind === "done" ? 0 : terminalKind === "blocked" ? 21 : 30,
   };
+  result.authoritative_comment = renderAuthoritativeComment(context, result);
+  return result;
 }
 
-function main() {
+async function main() {
   const command = process.argv[2];
   if (!command) printUsage();
 
@@ -555,6 +925,26 @@ function main() {
       first_delay_seconds: 30,
       schedule_message: buildScheduleMessage(context),
     }, null, 2));
+    process.exit(0);
+  }
+
+  if (command === "parse-artifact") {
+    const filePath = requireArg("--text-file");
+    const text = await readTextFile(filePath);
+    const result = tryParseArtifactFromText(text);
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.ok ? 0 : 22);
+  }
+
+  if (command === "render-handoff-comment") {
+    const context = validateContext(parseJson<OrchestratorContext>(requireArg("--context-json")));
+    const decision = parseJson<EvaluateResult>(requireArg("--decision-json"));
+    const comment = renderAuthoritativeComment(context, decision);
+    if (!comment) {
+      console.error("Decision does not contain transition_audit; cannot render authoritative comment.");
+      process.exit(23);
+    }
+    console.log(comment);
     process.exit(0);
   }
 
@@ -573,7 +963,7 @@ function main() {
       summary: getArg("--summary"),
       now: getArg("--now"),
     };
-    const result = evaluate(input);
+    const result = await evaluate(input);
     console.log(JSON.stringify(result, null, 2));
     process.exit(result.exit_code);
   }
@@ -581,4 +971,7 @@ function main() {
   printUsage();
 }
 
-main();
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/skills/multica-orchestrator/SKILL.md
+++ b/skills/multica-orchestrator/SKILL.md
@@ -2,19 +2,19 @@
 name: multica-orchestrator
 description: >
   Use when rara needs Multica issue stages to advance autonomously. This skill
-  defines the workflow controller contract that evaluates stage artifacts,
-  gates plan/build/review handoffs, triggers corrective follow-up, and escalates
-  when automatic transition is unsafe.
+  defines a controller-owned workflow contract that parses canonical stage
+  artifacts, validates plan/build/review gates, emits authoritative handoff
+  comments, and stops automatic transition when evidence is incomplete.
 ---
 
 Use this skill after work has already been represented in Multica issues and the
 next problem is no longer just "is the task still running?" but "is the stage
-ready to hand off automatically?"
+ready to hand off automatically and audibly?"
 
 This skill sits above `multica-team` and `multica-polling`.
 - `multica-team` decides the issue tree, issue bodies, dispatch contract, and ownership model
 - `multica-polling` tells rara whether a specific dispatched issue is still running, terminal, timed out, or unobservable
-- this skill decides whether a terminal stage result is good enough to advance the workflow without manual intervention
+- this skill is the workflow controller: it decides whether a terminal stage result is good enough to advance the workflow, and it produces the authoritative handoff record
 
 ## Files
 
@@ -29,11 +29,13 @@ Never advance to the next stage just because:
 - the task completed
 - the issue says `in_review`
 - the latest comment sounds confident
+- an agent recommends a next assignee in free-form prose
 
-Advance only when all three are true:
+Advance only when all four are true:
 1. the current stage reached a terminal execution result
-2. the stage artifact exists in the expected structure
-3. the stage validator passes
+2. the controller found a canonical `STAGE_RESULT` artifact
+3. the stage validator passed
+4. the controller emitted an authoritative transition decision
 
 If any of those fail, stop the handoff and choose one of:
 - `reschedule` for the same stage with a corrective follow-up
@@ -42,13 +44,13 @@ If any of those fail, stop the handoff and choose one of:
 
 ## Workflow shape
 
-This skill currently targets a simple staged coding pipeline:
+This skill targets a simple staged coding pipeline:
 - `plan`
 - `build`
 - `review`
 
 Default forward path:
-- `plan -> build -> review`
+- `plan -> build -> review -> done`
 
 Non-forward outcomes:
 - `reschedule` for same-stage correction or continued waiting
@@ -61,7 +63,7 @@ The workflow controller owns the stage decision.
 
 ## Operating model
 
-The orchestrator keeps a workflow state object that can be persisted in the
+The controller keeps a workflow state object that can be persisted in the
 scheduled message and echoed into issue comments for auditability.
 
 Minimum context shape:
@@ -69,7 +71,13 @@ Minimum context shape:
 ```json
 {
   "workflow": "multica_orchestrator",
+  "schema_version": 2,
   "root_issue_id": "ISSUE-100",
+  "workflow_graph": {
+    "plan": { "issue_id": "ISSUE-101", "assignee_label": "Planner" },
+    "build": { "issue_id": "ISSUE-102", "assignee_label": "Builder" },
+    "review": { "issue_id": "ISSUE-103", "assignee_label": "Reviewer" }
+  },
   "current_stage": "plan",
   "current_issue_id": "ISSUE-101",
   "next_stage": "build",
@@ -80,48 +88,53 @@ Minimum context shape:
   "handoff_ready": false,
   "escalation_count": 0,
   "max_stage_attempts": 2,
-  "history": []
+  "expected_delivery_mode": "commit+push",
+  "history": [],
+  "last_transition_audit": null
 }
 ```
 
-The exact implementation may evolve, but the meaning should remain stable:
-- identify the root issue tree
-- identify the current stage and issue
-- record the latest observed task identity/status
-- record whether validation passed
-- bound automatic retries
-- preserve a compact stage history
+The meaning should remain stable:
+- the controller owns the workflow graph
+- stage-to-issue mapping is explicit, not inferred from current comments
+- the latest observed task identity/status is persisted
+- validation state and retry budget are persisted
+- automatic handoff is gated by audit output, not by status labels
 
-## Stage result contract
+## Canonical stage result contract
 
 Automatic handoff only works if stage outputs are machine-checkable.
-Require the assigned agent to produce a final structured block in the issue
-comment or artifact.
+Require the assigned agent to produce a canonical JSON artifact in the final
+issue comment or artifact attachment.
 
-Preferred minimal format:
+Preferred canonical format:
 
 ```md
 ## STAGE_RESULT
-stage: plan
-status: ready_for_handoff
 
-## SUMMARY
-<short summary>
-
-## ARTIFACTS
-- observed_problem: ...
-- evidence: ...
-- root_cause: ...
-- acceptance_criteria: ...
-- risks: ...
-
-## NEXT_RECOMMENDATION
-assign: Devkit Build
+```json
+{
+  "schema_version": 1,
+  "stage": "plan",
+  "status": "ready_for_handoff",
+  "summary": "Problem and fix direction are clear.",
+  "comment_id": "comment-123",
+  "fields": {
+    "observed_problem": "...",
+    "evidence": "...",
+    "root_cause": "...",
+    "affected_surface": "...",
+    "implementation_shape": "...",
+    "acceptance_criteria": "...",
+    "risks": "..."
+  },
+  "next_recommendation": "handoff"
+}
+```
 ```
 
-The exact markdown prose around it may vary.
-The controller should parse by section headers / key-value markers rather than
-trusting free-form text.
+The controller should parse only the JSON artifact.
+Do not trust surrounding prose as the source of truth.
 
 ## Validator requirements
 
@@ -141,6 +154,7 @@ trusting free-form text.
 - commands/tests run
 - result of those commands/tests
 - residual risks or known gaps
+- delivery evidence matching the declared dispatch contract
 
 ### Review stage must include
 - verdict: `GO` or `NO_GO`
@@ -152,19 +166,49 @@ trusting free-form text.
 If a stage result misses any mandatory field, validation fails even if the task
 itself completed successfully.
 
+## Delivery-mode gate
+
+`build -> review` is not allowed on code changes alone.
+
+The controller must verify that the declared delivery mode was satisfied:
+- `commit+push`
+- `commit+push+pr`
+- `local-artifact`
+- `issue-comment`
+- `artifact+comment`
+
+Build artifacts must therefore include delivery evidence, for example:
+
+```json
+{
+  "delivery": {
+    "mode": "commit+push",
+    "status": "satisfied",
+    "branch": "feat/fix-x",
+    "commit_sha": "abc123",
+    "pr_url": null,
+    "artifact_path": null,
+    "comment_ref": "comment-456"
+  }
+}
+```
+
+If `expected_delivery_mode` is missing from controller context, build validation
+must fail. The controller is not allowed to guess what “done” meant.
+
 ## Transition policy
 
 ### `plan -> build`
 Advance only when:
 - the plan task is terminal success
 - the plan validator passes
-- the next build issue/owner is already known or can be derived safely
+- the next build issue is already known in `workflow_graph`
 
 Then:
-- produce a handoff summary
-- attach or post the authoritative plan result
+- produce an authoritative handoff summary
+- post the controller-generated handoff note
 - assign the build issue to the build agent
-- start polling / orchestration for the build stage
+- continue tracking on the build stage
 
 ### `build -> review`
 Advance only when:
@@ -173,10 +217,10 @@ Advance only when:
 - the delivery mode in the dispatch contract was actually satisfied
 
 Then:
-- produce a review handoff summary
-- include commit/branch/test evidence
+- produce an authoritative review handoff summary
+- include commit/branch/test/delivery evidence
 - assign the review issue to the review agent
-- start polling / orchestration for the review stage
+- continue tracking on the review stage
 
 ### `review -> done`
 Advance only when:
@@ -191,14 +235,14 @@ Then:
 
 ## Failure and correction policy
 
-### Missing structured artifact
-If the stage completed but the expected structured result is missing:
+### Missing canonical artifact
+If the stage completed but the canonical JSON result is missing:
 - keep the stage where it is
 - issue a corrective follow-up comment
-- request the missing fields explicitly
-- count this as `retry_same_stage`, not stage success
+- request the missing artifact explicitly
+- count this as same-stage correction, not stage success
 
-### Structured artifact exists but fails validation
+### Canonical artifact exists but fails validation
 If the artifact is present but incomplete or contradictory:
 - keep the stage where it is
 - report the exact missing/invalid fields
@@ -208,7 +252,7 @@ If the artifact is present but incomplete or contradictory:
 ### Task failure
 If the task itself failed or was cancelled:
 - do not hand off
-- record `blocked` or `retry_same_stage` based on the failure mode
+- record `blocked`
 - separate execution failure from validation failure
 
 ### Poller failure
@@ -230,23 +274,24 @@ Use `schedule-once` chaining, not free-running intervals.
 A typical loop is:
 1. inspect the current issue/task state
 2. if execution is non-terminal, reschedule
-3. if execution is terminal, parse the stage artifact
+3. if execution is terminal, parse the canonical stage artifact
 4. validate the artifact
 5. either hand off, retry same stage, or escalate
-6. persist the updated orchestrator context in the next scheduled message
+6. persist the updated orchestrator context plus transition audit in the next scheduled message
 
 ## Script contract
 
-The bundled controller script exposes three commands.
+The bundled controller script exposes five commands.
 
 ### 1. Initialize workflow context
 
 ```bash
 bun "${CLAUDE_PLUGIN_ROOT}/scripts/multica-orchestrate.ts" init \
   --root-issue-id ISSUE-100 \
-  --current-stage plan \
-  --current-issue-id ISSUE-101 \
-  --next-stage build
+  --plan-issue-id ISSUE-101 \
+  --build-issue-id ISSUE-102 \
+  --review-issue-id ISSUE-103 \
+  --expected-delivery-mode commit+push
 ```
 
 ### 2. Evaluate one stage observation
@@ -256,10 +301,32 @@ bun "${CLAUDE_PLUGIN_ROOT}/scripts/multica-orchestrate.ts" evaluate \
   --context-json '<json>' \
   --observed-state completed \
   --task-id TASK-123 \
-  --artifact-json '{"stage":"plan","fields":{"observed_problem":"...","evidence":"...","root_cause":"...","affected_surface":"...","implementation_shape":"...","acceptance_criteria":"...","risks":"..."}}'
+  --artifact-json '{"schema_version":1,"stage":"build","status":"ready_for_handoff","summary":"Build is ready.","comment_id":"comment-22","fields":{"branch":"feat/x","commit_sha":"abc123","changed_files":"src/a.ts","commands_run":"bun test","test_results":"pass","risks":"low"},"delivery":{"mode":"commit+push","status":"satisfied","branch":"feat/x","commit_sha":"abc123"}}'
 ```
 
-### 3. Rebuild the future scheduled message
+Output now includes:
+- `transition_audit`
+- `authoritative_comment`
+- `validation.delivery_check`
+
+### 3. Parse a canonical artifact from comment text
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/scripts/multica-orchestrate.ts" parse-artifact \
+  --text-file ./comment.md
+```
+
+This extracts the fenced JSON `STAGE_RESULT` block.
+
+### 4. Render the authoritative handoff / verdict comment
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/scripts/multica-orchestrate.ts" render-handoff-comment \
+  --context-json '<json>' \
+  --decision-json '<evaluate-result-json>'
+```
+
+### 5. Rebuild the future scheduled message
 
 ```bash
 bun "${CLAUDE_PLUGIN_ROOT}/scripts/multica-orchestrate.ts" schedule-message \
@@ -268,20 +335,37 @@ bun "${CLAUDE_PLUGIN_ROOT}/scripts/multica-orchestrate.ts" schedule-message \
 
 ## Result meanings
 
-The controller should distinguish these outcomes:
+The controller distinguishes these outcomes:
 - `reschedule` — still waiting on execution or a bounded correction round
-- `handoff` — current stage passed and the next stage should be dispatched
+- `handoff` — current stage passed and the next stage should be dispatched by the controller
 - `done` — workflow is complete
 - `blocked` — stage failed in a way that should stop autonomous progress
 - `needs_human` — ambiguity, repeated validator failure, or observation failure requires rara to intervene
 
 Do not collapse these into a generic success/failure boolean.
 
+## Transition audit
+
+Every terminal controller decision should be explainable with machine-readable
+audit data.
+
+Persist at least:
+- observed task state
+- current stage / issue / task identity
+- source artifact comment ID
+- artifact SHA-256
+- validator status
+- controller decision
+- next stage
+- summary
+
+This audit is part of the workflow contract, not optional debugging metadata.
+
 ## Recommended implementation pattern
 
 Keep responsibilities separate:
 - `multica-polling` handles task lifecycle observation
-- this skill handles stage lifecycle interpretation
+- this skill handles stage lifecycle interpretation and controller verdicts
 
 In code terms, the controller should usually consume a normalized execution state:
 - `no_run_yet`
@@ -292,25 +376,28 @@ In code terms, the controller should usually consume a normalized execution stat
 - `cancelled`
 - `poll_error`
 
-Then layer validation and transition logic on top.
+Then layer canonical parsing, validation, delivery verification, and transition
+comment generation on top.
 
 ## Anti-patterns
 
 Do not:
 - auto-advance on `completed` alone
 - auto-advance on issue status alone
+- trust free-form prose instead of canonical JSON
+- let an agent’s own next-step suggestion become the stage authority
 - hide the handoff reason in private scheduler state only
 - retry indefinitely without a stage attempt budget
 - merge task failure and poller failure into one vague error bucket
 - reassign to a different agent just because the previous output was under-specified
-- use free-form prose as the only validation input when a structured artifact was required
 
 ## Pre-flight checklist
 
 Before using this skill, verify:
 - [ ] the issue tree and stage ownership are already defined
-- [ ] each stage has a machine-checkable artifact contract
+- [ ] `workflow_graph` explicitly maps plan/build/review to issue IDs
+- [ ] each stage is instructed to emit canonical JSON `STAGE_RESULT`
 - [ ] polling or equivalent observation exists for the current issue
-- [ ] the next stage target is known before automatic handoff is attempted
+- [ ] `expected_delivery_mode` is known before automatic `build -> review` handoff
 - [ ] retry and escalation budgets are bounded
-- [ ] every automatic transition can be explained in an issue comment or summary
+- [ ] every automatic transition can be explained in an issue comment and in `transition_audit`

--- a/skills/multica-team/SKILL.md
+++ b/skills/multica-team/SKILL.md
@@ -65,7 +65,7 @@ Load these reference files when needed:
 - for concrete issue / comment structures → `references/issue-templates.md`
 - for decomposition, assignment, monitoring, and closure decisions → `references/operating-rules.md`
 - for sustained post-dispatch run tracking → switch to `multica-polling`
-- for automatic stage gating / handoff after dispatch → switch to `multica-orchestrator`
+- for automatic stage gating / controller-owned handoff after dispatch → switch to `multica-orchestrator`
 
 Use these primitives:
 - **Issue tree**: parent issue + child issues via `parent_issue_id`
@@ -78,6 +78,7 @@ Important constraint:
 - there is no reliable user-facing generic `create task` API to bypass issues
 - task creation is driven by issue assignment, comments, mentions, and chat
 - therefore, treat **issues as the primary orchestration unit**
+- if the workflow will auto-advance across `plan -> build -> review`, define the stage issue IDs and canonical `STAGE_RESULT` contract before dispatch
 
 ## Workflow checklist
 
@@ -176,7 +177,11 @@ Before dispatching, make sure the task text answers all of these:
    - if writable repo is unavailable, say what counts as a successful fallback
    - never make the agent infer this
 
-6. **Blocker reporting format**
+6. **Canonical stage result contract**
+   - if this issue is part of a controller-managed workflow, require the final comment to include a fenced JSON `STAGE_RESULT` block
+   - list the required stage-specific fields explicitly
+
+7. **Blocker reporting format**
    - require exact command, remote, path, and stderr when reporting git/repo failures
    - `git push failed` alone is not an acceptable blocker report
 
@@ -189,6 +194,7 @@ Before assigning or posting a corrective follow-up comment, confirm:
 - [ ] push destination is explicit when push is expected
 - [ ] success artifact is explicit
 - [ ] fallback behavior is explicit
+- [ ] canonical `STAGE_RESULT` requirement is explicit for controller-managed stages
 - [ ] blocker reporting expectations are explicit
 
 If any box is unchecked, fix the contract before dispatch.
@@ -250,6 +256,15 @@ A Multica task is only `done` when it matches the declared delivery mode.
 - if delivery mode is `commit + push`, artifact-only is not done
 - if delivery mode is `artifact + issue comment`, lack of repo access is not a failure
 - if delivery mode is ambiguous, fix the instruction before judging the agent
+- if the stage is controller-managed, build completion must include delivery evidence inside canonical `STAGE_RESULT`
+
+### Canonical stage result rules
+
+For controller-managed workflows:
+- each stage issue must require a final fenced JSON `STAGE_RESULT`
+- rara should specify the required stage fields up front
+- free-form prose may explain the result, but the JSON block is the machine-checkable source of truth
+- handoff authority stays with the controller, not with the agent that authored the artifact
 
 ### Minimal dispatch template
 

--- a/skills/multica-team/references/issue-templates.md
+++ b/skills/multica-team/references/issue-templates.md
@@ -18,6 +18,11 @@ Context:
 - Current state: <important facts only>
 - Why this matters: <product or operational reason>
 
+Workflow graph:
+- plan issue: <ISSUE-ID>
+- build issue: <ISSUE-ID>
+- review issue: <ISSUE-ID>
+
 Scope of this parent:
 - Coordinate the full objective across child issues
 - Track completion of all required implementation pieces
@@ -51,6 +56,8 @@ Use for a concrete deliverable that should be assigned to one agent.
 ```md
 Goal: <single clear deliverable>
 
+Stage: <plan | build | review>
+
 Context:
 - Repo / path: <orientation only>
 - Current state: <relevant facts>
@@ -72,11 +79,76 @@ Out of scope:
 
 Expected deliverables:
 - <code / docs / config / tests>
+- final issue comment containing the canonical `STAGE_RESULT` JSON block shown below
 
 Acceptance criteria:
 - <verifiable condition>
 - <verifiable condition>
+
+Canonical completion contract:
+- Your final issue comment must include a `## STAGE_RESULT` section.
+- Inside that section, include one fenced `json` block only.
+- The JSON block is the machine-readable source of truth.
+- Surrounding prose is optional and will not be treated as authoritative.
 ```
+
+### Canonical `STAGE_RESULT` template
+
+Use and fill the stage-specific fields:
+
+```md
+## STAGE_RESULT
+
+```json
+{
+  "schema_version": 1,
+  "stage": "<plan|build|review>",
+  "status": "ready_for_handoff",
+  "summary": "<short factual summary>",
+  "comment_id": "<optional-comment-id>",
+  "fields": {
+    "<required_field>": "<value>"
+  },
+  "delivery": {
+    "mode": "<commit+push|commit+push+pr|local-artifact|issue-comment|artifact+comment>",
+    "status": "<satisfied|fallback_used|missing|not_applicable>",
+    "branch": "<branch-or-null>",
+    "commit_sha": "<sha-or-null>",
+    "pr_url": "<url-or-null>",
+    "artifact_path": "<path-or-null>",
+    "comment_ref": "<comment-or-null>"
+  },
+  "verdict": "<GO|NO_GO only for review>",
+  "next_recommendation": "<handoff|blocked|done>"
+}
+```
+```
+
+### Stage-specific required fields
+
+#### Plan
+- `observed_problem`
+- `evidence`
+- `root_cause`
+- `affected_surface`
+- `implementation_shape`
+- `acceptance_criteria`
+- `risks`
+
+#### Build
+- `branch`
+- `commit_sha`
+- `changed_files`
+- `commands_run`
+- `test_results`
+- `risks`
+- plus `delivery.*` evidence matching the dispatch contract
+
+#### Review
+- `verdict`
+- `evidence`
+- `risks`
+- `next_action`
 
 ### Title examples
 - Add <capability>
@@ -105,6 +177,7 @@ Constraints:
 Done when:
 - <verification check>
 - <verification check>
+- the final comment contains a corrected canonical `STAGE_RESULT` JSON block
 ```
 
 ### Good use cases
@@ -112,6 +185,7 @@ Done when:
 - add a missing test
 - fix a review finding
 - align implementation with a clarified requirement
+- repair a malformed `STAGE_RESULT` artifact
 
 ### Bad use cases
 - introducing a materially new scope
@@ -131,6 +205,7 @@ Checked:
 - <correctness>
 - <tests / build / lint>
 - <architecture or scope fit>
+- <delivery mode satisfied or not>
 
 Notes:
 - <important finding>
@@ -158,6 +233,40 @@ Current state:
 
 Continue from:
 - <starting point / branch / artifact / comment thread>
+
+Controller note:
+- authoritative handoff comment: <link or quote>
 ```
 
 Keep reassignment rare and intentional. In Multica, changing assignee can cancel current task execution and enqueue work for the new assignee.
+
+---
+
+## 6) Authoritative handoff note template
+
+Use when the workflow controller approves a transition.
+
+```md
+## WORKFLOW_CONTROLLER_DECISION
+stage: <plan|build|review>
+issue_id: <ISSUE-ID>
+task_id: <TASK-ID or n/a>
+observed_state: <completed|failed|cancelled|poll_error>
+validator_status: <passed|failed|pending>
+decision: <handoff|blocked|done|needs_human>
+next_stage: <build|review|done|n/a>
+artifact_comment_id: <comment-id or n/a>
+artifact_sha256: <sha or n/a>
+
+## SUMMARY
+<controller summary>
+
+## VALIDATION
+summary: <validation summary>
+delivery_check: <delivery gate summary>
+
+## NEXT_ACTION
+<authoritative reassignment or escalation instruction>
+```
+
+This comment is emitted by the controller, not by the stage agent. It is the audit record for why the workflow moved or stopped.

--- a/skills/multica-team/references/operating-rules.md
+++ b/skills/multica-team/references/operating-rules.md
@@ -14,6 +14,7 @@ Use **parent + child issues** when:
 - implementation and docs are distinct workstreams
 - rollout / migration / cleanup should be tracked independently
 - one prompt would be too broad to verify reliably
+- stage ownership should be explicit across `plan -> build -> review`
 
 Rule of thumb:
 - if success cannot be described with 2–4 concrete acceptance checks, split it
@@ -37,6 +38,7 @@ Avoid comments like:
 - "do more"
 
 Always restate the concrete delta.
+If the stage is controller-managed, always restate which canonical artifact fields must be corrected.
 
 ## 3) Assignment is dispatch
 
@@ -47,6 +49,7 @@ Therefore:
 - do not reassign casually
 - do not bundle unrelated deliverables into one assignee round
 - if ownership changes, leave a handoff comment
+- when the workflow controller approves a transition, use its authoritative handoff note as the source of truth
 
 Good reasons to reassign:
 - agent specialization mismatch
@@ -56,6 +59,7 @@ Good reasons to reassign:
 Bad reasons to reassign:
 - impatience without diagnosis
 - vague hope that another agent will guess better
+- free-form agent suggestion without controller validation
 
 ## 4) Monitor using both push and pull
 
@@ -69,6 +73,7 @@ Watch for:
 - task starts but produces no progress
 - repeated failure or cancellation
 - issue status claiming done while evidence is incomplete
+- stage completion comment missing a canonical `STAGE_RESULT`
 
 If signals conflict, trust artifacts and run history over superficial status labels.
 
@@ -78,12 +83,15 @@ Never close work only because:
 - the agent said it is done
 - the issue status says done
 - one child issue succeeded
+- a comment sounds like a handoff
 
 Close only after checking:
 - requested behavior exists
 - acceptance criteria are actually met
 - tests / lint / build status are acceptable
 - no obvious scope gaps remain
+- canonical `STAGE_RESULT` exists and validates
+- build delivery mode actually matches the dispatch contract
 
 For larger tasks, record a simple verdict:
 - `GO`
@@ -95,6 +103,7 @@ A parent issue can close only when:
 - required child issues are complete
 - the integrated outcome matches the parent goal
 - verification passed at the whole-task level
+- the controller state is `done` or intentionally superseded by a human decision
 
 Do not use parent closure as a convenience marker.
 
@@ -111,6 +120,11 @@ Do not use parent closure as a convenience marker.
 - tighten acceptance criteria
 - consider reassignment only with a clear reason
 
+### If canonical artifact validation fails
+- list exact missing or invalid fields
+- request a corrected `STAGE_RESULT`
+- do not advance ownership yet
+
 ### After two failed rounds overall
 - surface the trade-off to the user
 - explain the blocker plainly
@@ -124,6 +138,7 @@ Split before dispatch if the request includes two or more of these:
 - user-facing changes plus internal refactor
 - implementation plus migration
 - implementation plus documentation / rollout prep
+- different natural owners for plan/build/review
 
 ### When to stay in one issue
 Keep one issue if the task is roughly:
@@ -139,5 +154,22 @@ If an agent misses the mark, improve one of these before retrying:
 - out-of-scope section
 - context facts
 - follow-up precision
+- canonical artifact schema instructions
+- delivery-mode contract clarity
 
 Do not compensate for weak instructions by repeatedly saying the same thing louder.
+
+## 10) Controller-owned handoff principle
+
+Once a workflow is controller-managed:
+- agents submit evidence
+- the controller validates evidence
+- rara posts the authoritative handoff note
+- only then should assignee changes happen
+
+Do not let stage progression be inferred from:
+- issue status alone
+- free-form prose alone
+- an agent's own recommendation alone
+
+The controller is the stage authority.


### PR DESCRIPTION
## Summary
- make the workflow controller own stage handoff authority in Multica orchestrator
- add canonical fenced JSON `STAGE_RESULT` parsing, transition audit output, and authoritative handoff comment rendering
- enforce build-stage delivery evidence before handoff and update Multica skill/docs to match the new controller contract

## Testing
- `bun scripts/multica-orchestrate.ts init --root-issue-id ISSUE-100 --plan-issue-id ISSUE-101 --build-issue-id ISSUE-102 --review-issue-id ISSUE-103 --expected-delivery-mode commit+push`
- `bun scripts/multica-orchestrate.ts parse-artifact --file .tmp-stage-result.md`
- `bun scripts/multica-orchestrate.ts evaluate ...` happy path with satisfied delivery evidence
- `bun scripts/multica-orchestrate.ts render-handoff-comment ...`
- `bun scripts/multica-orchestrate.ts evaluate ...` failure path with missing delivery satisfaction
