### PR TITLE
docs: simplify Rara-to-Multica contract

### DIFF
--- a/skills/dev-workflow/SKILL.md
+++ b/skills/dev-workflow/SKILL.md
@@ -87,6 +87,47 @@ Examples of conflicts to surface (do not silently comply):
 
 ## L6 — Interaction Design
 
+### Review-state discipline
+
+Treat `in_review` as a short review gate.
+It means there is already a concrete artifact set and Rara is waiting for an explicit review decision.
+
+For single-issue work, move into `in_review` only when the reviewable package is real:
+- commit exists
+- PR exists when the task is repo-backed
+- verification proof is recorded in the PR body, issue comments, or both
+- the issue contains a durable change summary
+
+Then:
+- move to `done` when review gives a clear `GO` or `GO_WITH_NOTES`
+- move to `blocked` when review gives `NO_GO`, or when the remaining gap is an external dependency rather than a review judgment
+
+For multi-lane work:
+- plan lanes move to `done` after their handoff artifact has been consumed
+- build lanes move to `done` after their artifact has been consumed by the review lane
+- review lanes carry the verdict and move to `done` or `blocked`
+
+If an issue is sitting in `in_review` with an already-clear final state, correct it immediately so the workflow stays readable.
+
+### Repo-backed closure gate
+
+For repo-backed coding tasks, `done` requires a complete delivery chain:
+- commit pushed on the declared branch
+- PR exists when the task is meant to land through normal repo review
+- verification proof is recorded durably
+- the issue contains a durable summary of what changed and any residual risk
+- an explicit review verdict is recorded before closure
+
+If one of those artifacts is missing, the work is not ready for closure even if the code itself looks complete.
+
+### Blocked-state taxonomy
+
+Use `blocked` precisely:
+- `quality blocked`: review or validation failed, so the next move is a focused fix round with the exact defect list
+- `environment blocked`: checkout, repo capability, credentials, toolchain, or similar infrastructure is missing, so the next move is to repair the environment or use the declared fallback path
+
+Do not collapse these into one generic blocker label. The recovery action depends on the blocker type.
+
 ### State Machine
 
 ```
@@ -102,8 +143,8 @@ Examples of conflicts to surface (do not silently comply):
 | Triage | User describes task | Tier determined, issue created | Never |
 | Plan | Medium+ tier | Spec written with deliverables | Small tier only |
 | Delegate | Issue + worktree exist | Agent completes, code committed | Never |
-| Verify | Delegation done | Build green + evaluator GO (large+) | Never |
-| Ship | Verification passed | PR created, CI green | Never |
+| Verify | Delegation done | Build green + evaluator GO (large+) + verification proof captured | Never |
+| Ship | Verification passed | PR created, durable issue summary recorded, explicit review verdict recorded, CI green | Never |
 
 **Rollback:**
 - Delegate fails → re-read error, craft targeted fix instruction, re-delegate

--- a/skills/dev-workflow/SKILL.md
+++ b/skills/dev-workflow/SKILL.md
@@ -1,9 +1,23 @@
 ---
 name: dev-workflow
 description: >
-  Use when implementing features, fixing bugs, reviewing code, creating PRs,
-  or performing any code-related development task.
+  Use when the user asks Rara to get code work done. Keep the user-facing
+  contract simple: they describe the outcome, Rara chooses the execution path,
+  and Rara reports progress and results back.
 ---
+
+## L0 — User Contract
+
+The user talks to Rara, not to an internal workflow.
+
+Default contract:
+- the user states the requirement in normal language
+- Rara decides whether to work locally or delegate
+- if Rara delegates, Multica stays behind the curtain as the execution layer
+- Rara reports meaningful status and final outcome back to the user
+
+Do not make the user learn internal role names, lane mechanics, or controller
+concepts unless that trade-off matters to a decision they need to make.
 
 ## L1 — Philosophy
 
@@ -66,7 +80,7 @@ When the workflow requirements conflict with what the user is asking:
 4. Proceed with user's choice only after they've seen the trade-off
 
 Examples of conflicts to surface (do not silently comply):
-- User asks you to write code directly → explain role separation
+- User asks you to choose a different execution path than the default → explain the trade-off
 - User asks to skip issue creation → explain traceability cost
 - User wants to merge with CI pending → state the risk
 - User asks generator to self-evaluate → explain blind spot research

--- a/skills/multica-team/SKILL.md
+++ b/skills/multica-team/SKILL.md
@@ -1,25 +1,35 @@
 ---
 name: multica-team
 description: >
-  Use whenever the user asks rara to handle coding work through Multica. rara
-  should translate the request into Multica-native issues, assign work to agent
-  teammates, track execution through task runs / comments / websocket events,
-  and drive follow-up until the work is verified and shipped.
+  Use when the user asks Rara to get coding work done and Multica is the right
+  execution path. The user-facing contract stays simple: Rara turns the request
+  into Multica work behind the scenes, tracks it, and reports status and
+  results back without making the user manage Multica mechanics.
 ---
 
-IRON LAW: RARA LEADS, MULTICA IMPLEMENTS. FOR CODING WORK, DEFAULT TO TURNING
-THE REQUEST INTO TRACKABLE MULTICA ISSUES AND DRIVING THE TEAM THROUGH TO A
-VERIFIED RESULT. DO NOT START WITH DIRECT LOCAL IMPLEMENTATION UNLESS THE USER
-EXPLICITLY ASKS RARA TO CODE LOCALLY INSTEAD OF USING MULTICA.
+IRON LAW: THE USER TALKS TO RARA. RARA MAY USE MULTICA TO IMPLEMENT, BUT
+MULTICA IS THE INTERNAL EXECUTION LAYER, NOT THE USER-FACING PRODUCT SURFACE.
+
+## User-facing contract
+
+Keep the user contract low-ceremony:
+- the user tells Rara what outcome they want
+- Rara decides whether Multica is the right execution path
+- if Multica is used, Rara translates the request into issues, assignments, and follow-up internally
+- Rara reports progress, blockers, and final outcome back in normal language
+
+Do not make the user choose team shape, lane structure, controller mode, or
+artifact schema unless that detail changes a real product or delivery decision.
 
 ## What this skill is for
 
 This skill is for rara herself.
 
 When the user asks for coding work, the default operating model is:
-- rara is planner / dispatcher / reviewer / closer
-- Multica agents are implementers
-- issues are the source of truth for execution
+- Rara owns the user conversation
+- Multica owns delegated execution
+- issues are the durable source of truth for execution
+- Rara turns Multica state into user-readable status
 - verification happens before ship, not after
 
 This skill is for:
@@ -37,7 +47,9 @@ Do not use this skill for:
 
 ## Decision rule: Multica team or direct local work?
 
-Default answer: **use Multica team**.
+Default answer: **the user talks to Rara; Rara chooses the execution path**.
+
+Use Multica team by default when delegated execution adds value.
 
 Use this skill when one or more are true:
 - the user asked rara to handle coding work and did not explicitly request local coding
@@ -51,7 +63,7 @@ Switch to direct local implementation only when one or more are true:
 - the user needs an in-session local patch rather than team dispatch
 
 If there is tension between the workflow and the user's request, surface it plainly:
-- state the default team workflow
+- state the default execution path
 - state the reason for it
 - state the trade-off of bypassing it
 - follow the user's explicit choice
@@ -70,6 +82,10 @@ Load these reference files when needed:
 - for sustained post-dispatch run tracking → switch to `multica-polling`
 - for automatic stage gating / controller-owned handoff after dispatch → switch to `multica-orchestrator`
 
+These references are for rara and internal agents.
+Do not front-load this vocabulary to the user unless it is necessary to explain
+an actual trade-off or blocker.
+
 Use these primitives:
 - **Issue tree**: parent issue + child issues via `parent_issue_id`
 - **Dispatch**: assign issue to an agent with `assignee_type=agent` and `assignee_id`
@@ -81,7 +97,7 @@ Important constraint:
 - there is no reliable user-facing generic `create task` API to bypass issues
 - task creation is driven by issue assignment, comments, mentions, and chat
 - therefore, treat **issues as the primary orchestration unit**
-- if the workflow will auto-advance across `plan -> build -> review`, define the stage issue IDs and canonical `STAGE_RESULT` contract before dispatch
+- if the workflow will auto-advance under the controller, define the relevant issue IDs and canonical result artifact contract before dispatch
 
 Protocol authority:
 - `references/team-protocol-v0.1.md` is the authoritative team model for role boundaries, handoff rules, convergence, gates, and closure
@@ -93,12 +109,15 @@ Protocol authority:
 Multica should be run as a **team coordination system**, not just a one-issue
 one-agent dispatcher.
 
-Use this mental model:
+Use this mental model internally:
 - **rara** is the team lead
 - **parent issue** is the team board / shared objective
 - **child issue** is a teammate-owned lane
 - **controller comment** is shared memory with authority
 - **canonical artifact** is the durable handoff medium between teammates
+
+The user does not need this model to ask for work.
+Rara should absorb that complexity and expose only useful status.
 
 This means:
 - a child issue is not just a task ticket; it defines ownership for one lane of work
@@ -192,7 +211,7 @@ Teammates may coordinate across lanes, but coordination must be durable and audi
 Allowed coordination media:
 - issue comments
 - parent issue summaries
-- canonical `STAGE_RESULT` artifacts
+- canonical controller artifacts such as `LANE_RESULT`
 - controller-authored handoff notes
 
 Do not treat these as authoritative on their own:
@@ -309,7 +328,9 @@ If choosing local work, stop using this skill and switch workflows cleanly.
 
 ### Decide the team shape
 
-If you stay in Multica, choose one of these deliberately:
+If you stay in Multica, choose one of these deliberately.
+This is an internal execution choice; do not offload it to the user unless the
+trade-off itself needs approval:
 - **single-agent** for one coherent deliverable
 - **staged-team** for `plan -> build -> review`
 - **parallel-lanes** for separable workstreams
@@ -415,8 +436,8 @@ Before dispatching, make sure the task text answers all of these:
    - never make the agent infer this
 
 6. **Canonical stage result contract**
-   - if this issue is part of a controller-managed workflow, require the final comment to include a fenced JSON `STAGE_RESULT` block
-   - list the required stage-specific fields explicitly
+   - if this issue is part of a controller-managed workflow, require the final comment to include the canonical fenced JSON artifact expected by the controller, such as `LANE_RESULT`
+   - list the required lane- or stage-specific fields explicitly
 
 7. **Blocker reporting format**
    - require exact command, remote, path, and stderr when reporting git/repo failures
@@ -437,7 +458,7 @@ Before assigning or posting a corrective follow-up comment, confirm:
 - [ ] push destination is explicit when push is expected
 - [ ] success artifact is explicit
 - [ ] fallback behavior is explicit
-- [ ] canonical `STAGE_RESULT` requirement is explicit for controller-managed stages
+- [ ] canonical controller artifact requirement is explicit for controller-managed work
 - [ ] blocker reporting expectations are explicit
 - [ ] team shape is explicit when work spans multiple lanes
 - [ ] lane boundary is explicit when more than one teammate is involved
@@ -503,13 +524,13 @@ A Multica task is only `done` when it matches the declared delivery mode.
 - if delivery mode is `commit + push`, artifact-only is not done
 - if delivery mode is `artifact + issue comment`, lack of repo access is not a failure
 - if delivery mode is ambiguous, fix the instruction before judging the agent
-- if the stage is controller-managed, build completion must include delivery evidence inside canonical `STAGE_RESULT`
+- if the workflow is controller-managed, completion must include delivery evidence inside the canonical controller artifact
 
-### Canonical stage result rules
+### Canonical controller artifact rules
 
 For controller-managed workflows:
-- each stage issue must require a final fenced JSON `STAGE_RESULT`
-- rara should specify the required stage fields up front
+- each controller-managed issue must require the final fenced JSON artifact expected by that controller, such as `LANE_RESULT`
+- rara should specify the required fields up front
 - free-form prose may explain the result, but the JSON block is the machine-checkable source of truth
 - handoff authority stays with the controller, not with the agent that authored the artifact
 
@@ -612,7 +633,7 @@ Ready means:
 
 Do not assign work that still depends on implied boundaries or oral memory.
 
-If the work is controller-managed, confirm the canonical `STAGE_RESULT` contract is present before assignment.
+If the work is controller-managed, confirm the canonical controller artifact contract is present before assignment.
 
 Core rule:
 - assigning an issue to a ready agent is the main task-dispatch path

--- a/skills/multica-team/SKILL.md
+++ b/skills/multica-team/SKILL.md
@@ -126,6 +126,103 @@ This means:
 - sibling lanes may coordinate, but only through durable comments or canonical artifacts
 - downstream teammates should consume validated artifacts, not guess from prose or status labels
 
+## Status semantics and review flow
+
+Treat issue status as a workflow state, not as a vague activity marker.
+
+### Status meanings
+- `backlog`: captured but not ready to run
+- `todo`: ready for execution
+- `in_progress`: the assigned lane is actively executing or waiting on the current execution round
+- `in_review`: waiting for an explicit review decision on a concrete artifact set
+- `done`: the lane or single-issue objective is complete
+- `blocked`: progress is stopped by a failed review verdict, missing dependency, or missing environment capability
+
+### Core rule for `in_review`
+`in_review` should be brief.
+It means a concrete artifact set already exists and rara is waiting for a review verdict.
+It should not be used as a long-term holding state for tasks that are really complete or really blocked.
+
+### Repo-backed completion hard gate
+For repo-backed coding work, neither a single issue nor a parent objective may close until the delivery chain is real and durable:
+- commit exists on the declared branch
+- PR exists when the delivery mode expects repo-backed review
+- verification proof is recorded in the PR body, issue comments, or both
+- the issue or parent contains a durable summary of what changed and any residual risk
+- an explicit review verdict such as `GO` or `GO_WITH_NOTES` is recorded by the review owner
+
+If any link in that chain is missing:
+- keep the issue in `in_progress` while delivery evidence is still being assembled
+- keep the issue in `in_review` only when the evidence is complete and a review decision is genuinely pending
+- move to `blocked` only when the next required step cannot proceed without outside help
+
+Artifact-only claims, branch-only claims, or agent self-declared completion do not satisfy repo-backed closure.
+
+### Single-issue flow
+For a single issue, use this shape:
+- `todo`
+- `in_progress`
+- `in_review`
+- `done` or `blocked`
+
+Move a single issue into `in_review` only when the reviewable artifact set is real.
+For repo-backed code work, that usually means:
+- commit exists
+- PR exists
+- verification proof exists in the PR body, issue comments, or both
+- the issue contains a durable change summary
+
+Move a single issue from `in_review` to:
+- `done` when there is an explicit review verdict such as `GO` or `GO_WITH_NOTES`
+- `blocked` when review produces `NO_GO`, or when the remaining gap is an external dependency rather than review judgment
+
+### Multi-lane flow
+For staged-team or hybrid work, keep the review decision on the review lane.
+Do not let build lanes sit in `in_review` after their artifact has already been handed off.
+
+Recommended staged flow:
+- plan lane produces a durable handoff artifact, then moves to `done` once consumed
+- build lane produces code, tests, commit, PR, and handoff artifact, then moves to `done` once the review lane has consumed that artifact
+- review lane carries the explicit verdict and then moves to `done` or `blocked`
+- parent issue closes only after all required lanes converge
+
+### Blocked taxonomy and recovery rule
+`blocked` needs a cause type, not just a terminal label.
+
+Use at least these two categories:
+- `quality blocked`: review, validation, or contract checks failed
+- `environment blocked`: missing checkout, missing repo capability, missing credentials, missing toolchain, broken CI primitive, or similar infrastructure gap
+
+Default next action:
+- `quality blocked`: keep the parent open, post the exact defect list or missing evidence, and create or continue a focused recovery round owned by the lane that can fix it
+- `environment blocked`: repair the repo contract or environment first; if a compliant fallback delivery mode exists, use it; otherwise report the exact failing command, repo path, remote, and stderr, then block the affected issue and any parent that cannot proceed without that capability
+
+Do not hide blocked taxonomy from the user behind jargon. rara should translate it into plain status, but the internal contract should preserve the exact blocked cause.
+
+### Parent convergence after child terminal states
+A child moving to `done` means the lane contract was satisfied.
+It does not mean the parent objective is satisfied.
+
+When all required children are `done`, rara must still perform explicit parent convergence:
+- verify the integrated outcome against the parent goal
+- confirm any required convergence note or review lane verdict exists
+- only then move the parent to `done`
+
+When a required child becomes `blocked`:
+- do not close the parent
+- if a recovery round is available inside the current workflow, keep the parent in `in_progress` and create or continue that recovery lane explicitly
+- if no compliant recovery path exists without outside help, move the parent to `blocked`
+
+Optional or superseded lanes should be marked explicitly in the parent record rather than silently counted as required convergence.
+
+### Stale-state correction rule
+When rara finds an issue in `in_review` that already has a durable final state, rara should correct it immediately:
+- if the issue already has a clear `GO` path and the delivery chain is complete, move it to `done`
+- if the issue already has a clear `NO_GO` or an environmental stop, move it to `blocked`
+- if a build artifact has already been consumed by a separate review lane, move the build lane to `done`
+
+This keeps Multica status readable for the user and keeps the internal workflow honest.
+
 ## Team shapes
 
 Choose the simplest shape that fits the work.
@@ -877,6 +974,7 @@ Parent closure rule:
 - do not close the parent because one child succeeded
 - do not use parent closure as a convenience marker
 - close the parent only when all required children are complete and the integrated outcome meets the parent goal
+- if a required child is `blocked`, keep the parent open for an explicit recovery lane or move the parent to `blocked`; never treat a blocked child as implied convergence
 - if the work used parallel lanes, confirm convergence explicitly before parent closure
 
 ## 10. Report back clearly to the user

--- a/skills/multica-team/references/operating-rules.md
+++ b/skills/multica-team/references/operating-rules.md
@@ -2,30 +2,49 @@
 
 These rules make `multica-team` predictable and easier to run consistently.
 
-## 1) Choose the unit of work carefully
+## 1) Form the smallest team that can win
 
-Use **one issue** when:
+Use **one issue / one agent** when:
 - the change is coherent
 - one agent can reasonably finish it in one focused round
 - review is straightforward
+- the task is mostly sequential
 
-Use **parent + child issues** when:
+Use a **staged team** when:
+- planning, build, and review should be separated clearly
+- stage ownership should be explicit across `plan -> build -> review`
+- machine-checkable handoff matters
+
+Use **parallel lanes** when:
 - frontend and backend are separable
 - implementation and docs are distinct workstreams
 - rollout / migration / cleanup should be tracked independently
+- competing hypotheses can be tested in parallel
 - one prompt would be too broad to verify reliably
-- stage ownership should be explicit across `plan -> build -> review`
 
 Rule of thumb:
 - if success cannot be described with 2–4 concrete acceptance checks, split it
+- if two lanes would probably touch the same files, do not parallelize build yet
 
-## 2) Prefer issue creation over vague continuation
+## 2) Make lane boundaries explicit
+
+Whenever more than one teammate is active, each child issue should state:
+- what the lane owns
+- what it must not modify
+- what upstream artifact it should trust
+- what downstream artifact it must leave behind
+
+If those four points are missing, the lane boundary is not ready.
+Do not dispatch parallel build work on an unclear boundary.
+
+## 3) Prefer issue creation over vague continuation
 
 Create a **new child issue** when:
 - scope changed materially
 - a new deliverable emerged
 - ownership should be tracked separately
 - you want a clean audit trail
+- a sibling lane should own the new work instead of inheriting it silently
 
 Use **comment + @mention** when:
 - the issue already exists
@@ -40,7 +59,7 @@ Avoid comments like:
 Always restate the concrete delta.
 If the stage is controller-managed, always restate which canonical artifact fields must be corrected.
 
-## 3) Assignment is dispatch
+## 4) Assignment is dispatch
 
 In Multica, assignment is the main execution trigger.
 
@@ -55,13 +74,49 @@ Good reasons to reassign:
 - agent specialization mismatch
 - repeated blockage
 - change in scope needing different expertise
+- a lane boundary changed and ownership should move cleanly
 
 Bad reasons to reassign:
 - impatience without diagnosis
 - vague hope that another agent will guess better
 - free-form agent suggestion without controller validation
 
-## 4) Monitor using both push and pull
+## 5) Teammates coordinate through durable evidence
+
+Allowed coordination media:
+- issue comments
+- parent issue summaries
+- canonical `STAGE_RESULT`
+- controller-authored handoff notes
+
+Do not treat these as sufficient authority by themselves:
+- issue status alone
+- free-form prose alone
+- an agent's self-declared next owner
+- assumptions about what a sibling lane probably discovered
+
+Rule:
+- teammates may influence other lanes only through durable, reviewable outputs
+- the controller or rara decides whether a handoff is authoritative
+- downstream lanes should trust validated artifacts over memory or implication
+
+## 6) Avoid parallel file conflicts
+
+Do not run parallel build lanes when:
+- two lanes are expected to edit the same file
+- one lane's acceptance criteria depend on another lane's unfinished internals
+- the same branch must absorb multiple unfinished edits with no explicit strategy
+- ownership of a shared module is still ambiguous
+
+Parallel work is usually safe when:
+- research lanes inspect different hypotheses
+- frontend and backend are connected by a clear API contract
+- implementation and docs are separable
+- tests or verification can proceed against a stable implementation contract
+
+If conflict risk is unclear, converge first or keep one build owner.
+
+## 7) Monitor using both push and pull
 
 Preferred monitoring pattern:
 - use `/ws` for live events when available
@@ -74,10 +129,12 @@ Watch for:
 - repeated failure or cancellation
 - issue status claiming done while evidence is incomplete
 - stage completion comment missing a canonical `STAGE_RESULT`
+- sibling lanes drifting into overlapping scope
+- contradictory findings across sibling lanes
 
 If signals conflict, trust artifacts and run history over superficial status labels.
 
-## 5) Verification is a real gate
+## 8) Verification is a real gate
 
 Never close work only because:
 - the agent said it is done
@@ -90,24 +147,54 @@ Close only after checking:
 - acceptance criteria are actually met
 - tests / lint / build status are acceptable
 - no obvious scope gaps remain
-- canonical `STAGE_RESULT` exists and validates
+- canonical `STAGE_RESULT` exists and validates when required
 - build delivery mode actually matches the dispatch contract
+- any required lane convergence is complete
+
+For repo-backed work, treat the delivery chain as a hard gate:
+- commit exists on the declared branch
+- PR exists when the delivery mode requires repo-backed review
+- verification proof is recorded durably
+- the issue or parent contains a durable summary
+- review recorded an explicit verdict before closure
 
 For larger tasks, record a simple verdict:
 - `GO`
 - `NO_GO`
 
-## 6) Parent issue closure rule
+## 9) Convergence is a first-class step
+
+When work uses parallel lanes:
+- define how sibling outputs will rejoin before dispatch
+- decide who owns final synthesis
+- resolve contradictions explicitly
+- do not infer parent completion from child completion
+
+Good convergence owners:
+- rara
+- a dedicated review lane
+- a controller-managed handoff step
+
+Bad convergence pattern:
+- letting whichever child finished last imply the parent is done
+
+## 10) Parent issue closure rule
 
 A parent issue can close only when:
 - required child issues are complete
 - the integrated outcome matches the parent goal
 - verification passed at the whole-task level
 - the controller state is `done` or intentionally superseded by a human decision
+- any required convergence step has completed explicitly
+
+If a required child becomes `blocked`:
+- do not close the parent
+- keep the parent open only when a specific recovery lane or follow-up round is already defined
+- otherwise move the parent to `blocked`
 
 Do not use parent closure as a convenience marker.
 
-## 7) Failure handling
+## 11) Failure handling
 
 ### If a task run fails once
 - read the failure details
@@ -125,12 +212,27 @@ Do not use parent closure as a convenience marker.
 - request a corrected `STAGE_RESULT`
 - do not advance ownership yet
 
+### If work is quality blocked
+- treat it as a failed review or validation gate, not as an infrastructure outage
+- post the exact defect list or missing evidence
+- route a focused recovery round to the lane that can fix it
+
+### If work is environment blocked
+- repair the checkout, repo capability, credentials, toolchain, or declared repo contract first
+- use the declared fallback delivery mode if one exists
+- if no compliant recovery path exists, record the exact command, path, remote, and stderr, then move the affected issue and parent to `blocked`
+
+### If sibling lanes conflict
+- stop parallel drift
+- restate the authoritative boundary
+- decide whether to converge, re-scope, or pick one owner
+
 ### After two failed rounds overall
 - surface the trade-off to the user
 - explain the blocker plainly
 - propose the next best path
 
-## 8) Practical heuristics
+## 12) Practical heuristics
 
 ### When to split immediately
 Split before dispatch if the request includes two or more of these:
@@ -139,6 +241,7 @@ Split before dispatch if the request includes two or more of these:
 - implementation plus migration
 - implementation plus documentation / rollout prep
 - different natural owners for plan/build/review
+- competing plausible root causes
 
 ### When to stay in one issue
 Keep one issue if the task is roughly:
@@ -146,10 +249,11 @@ Keep one issue if the task is roughly:
 - a small feature with one obvious surface area
 - a low-risk refactor with clear boundaries
 
-## 9) Quality of instruction matters more than retry count
+## 13) Quality of instruction matters more than retry count
 
 If an agent misses the mark, improve one of these before retrying:
 - scope boundary
+- lane boundary
 - acceptance criteria
 - out-of-scope section
 - context facts
@@ -159,7 +263,7 @@ If an agent misses the mark, improve one of these before retrying:
 
 Do not compensate for weak instructions by repeatedly saying the same thing louder.
 
-## 10) Controller-owned handoff principle
+## 14) Controller-owned handoff principle
 
 Once a workflow is controller-managed:
 - agents submit evidence


### PR DESCRIPTION
## What changed
- simplify `skills/dev-workflow` so the top-level contract is: user tells Rara the desired outcome, Rara chooses the execution path, and Rara reports status/results back
- simplify `skills/multica-team` so Multica is clearly framed as the internal execution layer behind Rara
- reduce wording that pushes users to think in internal Multica concepts too early

## Verification proof
- `git diff --check -- skills/dev-workflow/SKILL.md skills/multica-team/SKILL.md`
- manual diff review of both touched files

## Scope
Touched files:
- `skills/dev-workflow/SKILL.md`
- `skills/multica-team/SKILL.md`

## Notes
- this PR carries commit `f404372dbc6f2bc5c169cd438518153865606aa6`
- unrelated in-progress local edits in other files were left out on purpose to keep this PR narrowly scoped

## Workflow
- Multica issue: `CRR-13`
